### PR TITLE
add loop to udp-conntrack tests to flush out kind flakiness

### DIFF
--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -82,8 +82,8 @@ kube::etcd::start() {
   else
     ETCD_LOGFILE=${ETCD_LOGFILE:-"/dev/null"}
   fi
-  kube::log::info "etcd --advertise-client-urls ${KUBE_INTEGRATION_ETCD_URL} --data-dir ${ETCD_DIR} --listen-client-urls http://${ETCD_HOST}:${ETCD_PORT} --debug > \"${ETCD_LOGFILE}\" 2>/dev/null"
-  etcd --advertise-client-urls "${KUBE_INTEGRATION_ETCD_URL}" --data-dir "${ETCD_DIR}" --listen-client-urls "${KUBE_INTEGRATION_ETCD_URL}" --debug 2> "${ETCD_LOGFILE}" >/dev/null &
+  kube::log::info "etcd --advertise-client-urls ${KUBE_INTEGRATION_ETCD_URL} --data-dir ${ETCD_DIR} --listen-client-urls http://${ETCD_HOST}:${ETCD_PORT} --log-level=debug > \"${ETCD_LOGFILE}\" 2>/dev/null"
+  etcd --advertise-client-urls "${KUBE_INTEGRATION_ETCD_URL}" --data-dir "${ETCD_DIR}" --listen-client-urls "${KUBE_INTEGRATION_ETCD_URL}" --log-level=debug 2> "${ETCD_LOGFILE}" >/dev/null &
   ETCD_PID=$!
 
   echo "Waiting for etcd to come up."

--- a/pkg/controller/endpointslicemirroring/reconciler_helpers_test.go
+++ b/pkg/controller/endpointslicemirroring/reconciler_helpers_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package endpointslicemirroring
 
 import (
+	"sort"
 	"testing"
 
 	discovery "k8s.io/api/discovery/v1beta1"
@@ -50,8 +51,8 @@ func TestRecycleSlices(t *testing.T) {
 		},
 		expectedSlices: &slicesByAction{
 			toUpdate: []*discovery.EndpointSlice{
-				simpleEndpointSlice("baz", "10.2.3.4", discovery.AddressTypeIPv4),
 				simpleEndpointSlice("bar", "10.1.2.3", discovery.AddressTypeIPv4),
+				simpleEndpointSlice("baz", "10.2.3.4", discovery.AddressTypeIPv4),
 			},
 		},
 	}, {
@@ -122,11 +123,19 @@ func TestRecycleSlices(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
-			recycleSlices(tc.startingSlices)
+			startingSlices := tc.startingSlices
+			recycleSlices(startingSlices)
 
-			expectEqualSlices(t, tc.startingSlices.toCreate, tc.expectedSlices.toCreate)
-			expectEqualSlices(t, tc.startingSlices.toUpdate, tc.expectedSlices.toUpdate)
-			expectEqualSlices(t, tc.startingSlices.toDelete, tc.expectedSlices.toDelete)
+			unorderedSlices := [][]*discovery.EndpointSlice{startingSlices.toCreate, startingSlices.toUpdate, startingSlices.toDelete}
+			for _, actual := range unorderedSlices {
+				sort.Slice(actual, func(i, j int) bool {
+					return actual[i].Name < actual[j].Name
+				})
+			}
+
+			expectEqualSlices(t, startingSlices.toCreate, tc.expectedSlices.toCreate)
+			expectEqualSlices(t, startingSlices.toUpdate, tc.expectedSlices.toUpdate)
+			expectEqualSlices(t, startingSlices.toDelete, tc.expectedSlices.toDelete)
 		})
 	}
 }

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -17,7 +17,6 @@ limitations under the License.
 package network
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -615,6 +614,32 @@ func testHTTPHealthCheckNodePort(ip string, port int, request string) (bool, err
 	return false, fmt.Errorf("unexpected HTTP response code %s from health check responder at %s", resp.Status, url)
 }
 
+func testHTTPHealthCheckNodePortFromTestContainer(config *e2enetwork.NetworkingTestConfig, host string, port int, timeout time.Duration, expectSucceed bool, threshold int) error {
+	count := 0
+	pollFn := func() (bool, error) {
+		statusCode, err := config.GetHTTPCodeFromTestContainer(
+			"/healthz",
+			host,
+			port)
+		if err != nil {
+			framework.Logf("Got error reading status code from http://%s:%d/healthz via test container: %v", host, port, err)
+			return false, nil
+		}
+		framework.Logf("Got status code from http://%s:%d/healthz via test container: %d", host, port, statusCode)
+		success := statusCode == 200
+		if (success && expectSucceed) ||
+			(!success && !expectSucceed) {
+			count++
+		}
+		return count >= threshold, nil
+	}
+	err := wait.PollImmediate(time.Second, timeout, pollFn)
+	if err != nil {
+		return fmt.Errorf("error waiting for healthCheckNodePort: expected at least %d succeed=%v on %v:%v/healthz, got %d", threshold, expectSucceed, host, port, count)
+	}
+	return nil
+}
+
 // Does an HTTP GET, but does not reuse TCP connections
 // This masks problems where the iptables rule has changed, but we don't see it
 func httpGetNoConnectionPoolTimeout(url string, timeout time.Duration) (*http.Response, error) {
@@ -681,6 +706,23 @@ func waitForApiserverUp(c clientset.Interface) error {
 		}
 	}
 	return fmt.Errorf("waiting for apiserver timed out")
+}
+
+// getEndpointNodesWithInternalIP returns a map of nodenames:internal-ip on which the
+// endpoints of the Service are running.
+func getEndpointNodesWithInternalIP(jig *e2eservice.TestJig) (map[string]string, error) {
+	nodesWithIPs, err := jig.GetEndpointNodesWithIP(v1.NodeInternalIP)
+	if err != nil {
+		return nil, err
+	}
+	endpointsNodeMap := make(map[string]string, len(nodesWithIPs))
+	for nodeName, internalIPs := range nodesWithIPs {
+		if len(internalIPs) < 1 {
+			return nil, fmt.Errorf("no internal ip found for node %s", nodeName)
+		}
+		endpointsNodeMap[nodeName] = internalIPs[0]
+	}
+	return endpointsNodeMap, nil
 }
 
 var _ = SIGDescribe("Services", func() {
@@ -2885,11 +2927,18 @@ var _ = SIGDescribe("ESIPP [Slow]", func() {
 			framework.ExpectNoError(err)
 
 			// Make sure we didn't leak the health check node port.
-			threshold := 2
-			nodes, err := jig.GetEndpointNodes()
+			const threshold = 2
+			nodes, err := getEndpointNodesWithInternalIP(jig)
 			framework.ExpectNoError(err)
-			for _, ips := range nodes {
-				err := TestHTTPHealthCheckNodePort(ips[0], healthCheckNodePort, "/healthz", e2eservice.KubeProxyEndpointLagTimeout, false, threshold)
+			config := e2enetwork.NewNetworkingTestConfig(f, false, false)
+			for _, internalIP := range nodes {
+				err := testHTTPHealthCheckNodePortFromTestContainer(
+					config,
+					internalIP,
+					healthCheckNodePort,
+					e2eservice.KubeProxyLagTimeout,
+					false,
+					threshold)
 				framework.ExpectNoError(err)
 			}
 			err = cs.CoreV1().Services(svc.Namespace).Delete(context.TODO(), svc.Name, metav1.DeleteOptions{})
@@ -2923,17 +2972,20 @@ var _ = SIGDescribe("ESIPP [Slow]", func() {
 		}()
 
 		tcpNodePort := int(svc.Spec.Ports[0].NodePort)
-		endpointsNodeMap, err := jig.GetEndpointNodes()
-		framework.ExpectNoError(err)
-		path := "/clientip"
 
-		for nodeName, nodeIPs := range endpointsNodeMap {
-			nodeIP := nodeIPs[0]
-			ginkgo.By(fmt.Sprintf("reading clientIP using the TCP service's NodePort, on node %v: %v%v%v", nodeName, nodeIP, tcpNodePort, path))
-			content := GetHTTPContent(nodeIP, tcpNodePort, e2eservice.KubeProxyLagTimeout, path)
-			clientIP := content.String()
-			framework.Logf("ClientIP detected by target pod using NodePort is %s", clientIP)
-			if strings.HasPrefix(clientIP, "10.") {
+		endpointsNodeMap, err := getEndpointNodesWithInternalIP(jig)
+		framework.ExpectNoError(err)
+
+		dialCmd := "clientip"
+		config := e2enetwork.NewNetworkingTestConfig(f, false, false)
+
+		for nodeName, nodeIP := range endpointsNodeMap {
+			ginkgo.By(fmt.Sprintf("reading clientIP using the TCP service's NodePort, on node %v: %v:%v/%v", nodeName, nodeIP, tcpNodePort, dialCmd))
+			clientIP, err := GetHTTPContentFromTestContainer(config, nodeIP, tcpNodePort, e2eservice.KubeProxyLagTimeout, dialCmd)
+			framework.ExpectNoError(err)
+			framework.Logf("ClientIP detected by target pod using NodePort is %s, the ip of test container is %s", clientIP, config.TestContainerPod.Status.PodIP)
+			// the clientIP returned by agnhost contains port
+			if !strings.HasPrefix(clientIP, config.TestContainerPod.Status.PodIP) {
 				framework.Failf("Source IP was NOT preserved")
 			}
 		}
@@ -2970,13 +3022,13 @@ var _ = SIGDescribe("ESIPP [Slow]", func() {
 			framework.Failf("Service HealthCheck NodePort was not allocated")
 		}
 
-		ips := e2enode.CollectAddresses(nodes, v1.NodeExternalIP)
+		ips := e2enode.CollectAddresses(nodes, v1.NodeInternalIP)
 
 		ingressIP := e2eservice.GetIngressPoint(&svc.Status.LoadBalancer.Ingress[0])
 		svcTCPPort := int(svc.Spec.Ports[0].Port)
 
-		threshold := 2
-		path := "/healthz"
+		const threshold = 2
+		config := e2enetwork.NewNetworkingTestConfig(f, false, false)
 		for i := 0; i < len(nodes.Items); i++ {
 			endpointNodeName := nodes.Items[i].Name
 
@@ -2995,15 +3047,21 @@ var _ = SIGDescribe("ESIPP [Slow]", func() {
 
 			// HealthCheck should pass only on the node where num(endpoints) > 0
 			// All other nodes should fail the healthcheck on the service healthCheckNodePort
-			for n, publicIP := range ips {
+			for n, internalIP := range ips {
 				// Make sure the loadbalancer picked up the health check change.
 				// Confirm traffic can reach backend through LB before checking healthcheck nodeport.
 				e2eservice.TestReachableHTTP(ingressIP, svcTCPPort, e2eservice.KubeProxyLagTimeout)
 				expectedSuccess := nodes.Items[n].Name == endpointNodeName
 				port := strconv.Itoa(healthCheckNodePort)
-				ipPort := net.JoinHostPort(publicIP, port)
-				framework.Logf("Health checking %s, http://%s%s, expectedSuccess %v", nodes.Items[n].Name, ipPort, path, expectedSuccess)
-				err := TestHTTPHealthCheckNodePort(publicIP, healthCheckNodePort, path, e2eservice.KubeProxyEndpointLagTimeout, expectedSuccess, threshold)
+				ipPort := net.JoinHostPort(internalIP, port)
+				framework.Logf("Health checking %s, http://%s/healthz, expectedSuccess %v", nodes.Items[n].Name, ipPort, expectedSuccess)
+				err := testHTTPHealthCheckNodePortFromTestContainer(
+					config,
+					internalIP,
+					healthCheckNodePort,
+					e2eservice.KubeProxyEndpointLagTimeout,
+					expectedSuccess,
+					threshold)
 				framework.ExpectNoError(err)
 			}
 			framework.ExpectNoError(e2erc.DeleteRCAndWaitForGC(f.ClientSet, namespace, serviceName))
@@ -3069,8 +3127,7 @@ var _ = SIGDescribe("ESIPP [Slow]", func() {
 		}
 	})
 
-	// TODO: Get rid of [DisabledForLargeClusters] tag when issue #90047 is fixed.
-	ginkgo.It("should handle updates to ExternalTrafficPolicy field [DisabledForLargeClusters]", func() {
+	ginkgo.It("should handle updates to ExternalTrafficPolicy field", func() {
 		namespace := f.Namespace.Name
 		serviceName := "external-local-update"
 		jig := e2eservice.NewTestJig(cs, namespace, serviceName)
@@ -3103,42 +3160,71 @@ var _ = SIGDescribe("ESIPP [Slow]", func() {
 			framework.Failf("Service HealthCheck NodePort still present")
 		}
 
-		endpointNodeMap, err := jig.GetEndpointNodes()
+		epNodes, err := jig.ListNodesWithEndpoint()
 		framework.ExpectNoError(err)
-		noEndpointNodeMap := map[string][]string{}
-		for _, n := range nodes.Items {
-			if _, ok := endpointNodeMap[n.Name]; ok {
-				continue
+		// map from name of nodes with endpoint to internal ip
+		// it is assumed that there is only a single node with the endpoint
+		endpointNodeMap := make(map[string]string)
+		// map from name of nodes without endpoint to internal ip
+		noEndpointNodeMap := make(map[string]string)
+		for _, node := range epNodes {
+			ips := e2enode.GetAddresses(&node, v1.NodeInternalIP)
+			if len(ips) < 1 {
+				framework.Failf("No internal ip found for node %s", node.Name)
 			}
-			noEndpointNodeMap[n.Name] = e2enode.GetAddresses(&n, v1.NodeExternalIP)
+			endpointNodeMap[node.Name] = ips[0]
 		}
+		for _, n := range nodes.Items {
+			ips := e2enode.GetAddresses(&n, v1.NodeInternalIP)
+			if len(ips) < 1 {
+				framework.Failf("No internal ip found for node %s", n.Name)
+			}
+			if _, ok := endpointNodeMap[n.Name]; !ok {
+				noEndpointNodeMap[n.Name] = ips[0]
+			}
+		}
+		framework.ExpectNotEqual(len(endpointNodeMap), 0)
+		framework.ExpectNotEqual(len(noEndpointNodeMap), 0)
 
 		svcTCPPort := int(svc.Spec.Ports[0].Port)
 		svcNodePort := int(svc.Spec.Ports[0].NodePort)
 		ingressIP := e2eservice.GetIngressPoint(&svc.Status.LoadBalancer.Ingress[0])
 		path := "/clientip"
+		dialCmd := "clientip"
+
+		config := e2enetwork.NewNetworkingTestConfig(f, false, false)
 
 		ginkgo.By(fmt.Sprintf("endpoints present on nodes %v, absent on nodes %v", endpointNodeMap, noEndpointNodeMap))
-		for nodeName, nodeIPs := range noEndpointNodeMap {
-			ginkgo.By(fmt.Sprintf("Checking %v (%v:%v%v) proxies to endpoints on another node", nodeName, nodeIPs[0], svcNodePort, path))
-			GetHTTPContent(nodeIPs[0], svcNodePort, e2eservice.KubeProxyLagTimeout, path)
+		for nodeName, nodeIP := range noEndpointNodeMap {
+			ginkgo.By(fmt.Sprintf("Checking %v (%v:%v/%v) proxies to endpoints on another node", nodeName, nodeIP[0], svcNodePort, dialCmd))
+			_, err := GetHTTPContentFromTestContainer(config, nodeIP, svcNodePort, e2eservice.KubeProxyLagTimeout, dialCmd)
+			framework.ExpectNoError(err, "Could not reach HTTP service through %v:%v/%v after %v", nodeIP, svcNodePort, dialCmd, e2eservice.KubeProxyLagTimeout)
 		}
 
-		for nodeName, nodeIPs := range endpointNodeMap {
-			ginkgo.By(fmt.Sprintf("checking kube-proxy health check fails on node with endpoint (%s), public IP %s", nodeName, nodeIPs[0]))
-			var body bytes.Buffer
-			pollfn := func() (bool, error) {
-				result := e2enetwork.PokeHTTP(nodeIPs[0], healthCheckNodePort, "/healthz", nil)
-				if result.Code == 0 {
+		for nodeName, nodeIP := range endpointNodeMap {
+			ginkgo.By(fmt.Sprintf("checking kube-proxy health check fails on node with endpoint (%s), public IP %s", nodeName, nodeIP))
+			var body string
+			pollFn := func() (bool, error) {
+				// we expect connection failure here, but not other errors
+				resp, err := config.GetResponseFromTestContainer(
+					"http",
+					"healthz",
+					nodeIP,
+					healthCheckNodePort)
+				if err != nil {
+					return false, nil
+				}
+				if len(resp.Errors) > 0 {
 					return true, nil
 				}
-				body.Reset()
-				body.Write(result.Body)
+				if len(resp.Responses) > 0 {
+					body = resp.Responses[0]
+				}
 				return false, nil
 			}
-			if pollErr := wait.PollImmediate(framework.Poll, e2eservice.TestTimeout, pollfn); pollErr != nil {
+			if pollErr := wait.PollImmediate(framework.Poll, e2eservice.TestTimeout, pollFn); pollErr != nil {
 				framework.Failf("Kube-proxy still exposing health check on node %v:%v, after ESIPP was turned off. body %s",
-					nodeName, healthCheckNodePort, body.String())
+					nodeName, healthCheckNodePort, body)
 			}
 		}
 

--- a/test/integration/endpointslice/endpointslicemirroring_test.go
+++ b/test/integration/endpointslice/endpointslicemirroring_test.go
@@ -189,7 +189,7 @@ func TestEndpointSliceMirroring(t *testing.T) {
 				}
 			}
 
-			err = wait.PollImmediate(1*time.Second, 5*time.Second, func() (bool, error) {
+			err = wait.PollImmediate(1*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
 				lSelector := discovery.LabelServiceName + "=" + resourceName
 				esList, err := client.DiscoveryV1beta1().EndpointSlices(ns.Name).List(context.TODO(), metav1.ListOptions{LabelSelector: lSelector})
 				if err != nil {


### PR DESCRIPTION
```
➜  kubernetes git:(master) ✗ ./run.sh
+++ [0722 15:17:22] Building go targets for darwin/amd64:
    test/e2e/e2e.test
ERROR: node(s) already exist for a cluster with the name "three-node"
I0722 15:17:39.839590   54231 test_context.go:429] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
I0722 15:17:39.839658   54231 e2e.go:129] Starting e2e run "e4c3c117-20c7-4c56-ad3a-2025362177ea" on Ginkgo node 1
{"msg":"Test Suite starting","total":1,"completed":0,"skipped":0,"failed":0}
Running Suite: Kubernetes e2e suite
===================================
Random Seed: 1595445458 - Will randomize all specs
Will run 1 of 5240 specs

Jul 22 15:17:39.848: INFO: >>> kubeConfig: /Users/mfenwick/.kube/config
Jul 22 15:17:39.851: INFO: Waiting up to 30m0s for all (but 0) nodes to be schedulable
Jul 22 15:17:39.871: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
Jul 22 15:17:39.895: INFO: 12 / 12 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
Jul 22 15:17:39.895: INFO: expected 2 pod replicas in namespace 'kube-system', 2 are Running and Ready.
Jul 22 15:17:39.895: INFO: Waiting up to 5m0s for all daemonsets in namespace 'kube-system' to start
Jul 22 15:17:39.901: INFO: 3 / 3 pods ready in namespace 'kube-system' in daemonset 'kindnet' (0 seconds elapsed)
Jul 22 15:17:39.901: INFO: 3 / 3 pods ready in namespace 'kube-system' in daemonset 'kube-proxy' (0 seconds elapsed)
Jul 22 15:17:39.901: INFO: e2e test version: v1.20.0-alpha.0.307+ae7dce72ce8aa7-dirty
Jul 22 15:17:39.903: INFO: kube-apiserver version: v1.18.2
Jul 22 15:17:39.903: INFO: >>> kubeConfig: /Users/mfenwick/.kube/config
Jul 22 15:17:39.908: INFO: Cluster IP family: ipv4
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
[sig-network] Conntrack 
  should be able to preserve UDP traffic when server pod cycles for a NodePort service
  /Users/mfenwick/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/network/conntrack.go:120
[BeforeEach] [sig-network] Conntrack
  /Users/mfenwick/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:174
STEP: Creating a kubernetes client
Jul 22 15:17:39.912: INFO: >>> kubeConfig: /Users/mfenwick/.kube/config
STEP: Building a namespace api object, basename conntrack
Jul 22 15:17:39.949: INFO: No PodSecurityPolicies found; assuming PodSecurityPolicy is disabled.
STEP: Waiting for a default service account to be provisioned in namespace
[BeforeEach] [sig-network] Conntrack
  /Users/mfenwick/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/network/conntrack.go:95
[It] should be able to preserve UDP traffic when server pod cycles for a NodePort service
  /Users/mfenwick/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/network/conntrack.go:120
STEP: creating a UDP service svc-udp with type=NodePort in conntrack-1620
STEP: creating a client pod for probing the service svc-udp
Jul 22 15:17:42.031: INFO: Pod client logs: Wed Jul 22 19:17:40 UTC 2020
Wed Jul 22 19:17:40 UTC 2020 Try: 1

Wed Jul 22 19:17:40 UTC 2020 Try: 2

Wed Jul 22 19:17:40 UTC 2020 Try: 3

Wed Jul 22 19:17:40 UTC 2020 Try: 4

Wed Jul 22 19:17:40 UTC 2020 Try: 5

Wed Jul 22 19:17:40 UTC 2020 Try: 6

Wed Jul 22 19:17:40 UTC 2020 Try: 7

STEP: creating a backend pod pod-server-0 for the service svc-udp
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-0:[80]]
Jul 22 15:17:44.057: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-0:[80]]
STEP: checking client pod connected to the backend 0 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-1 for the service svc-udp
Jul 22 15:17:56.106: INFO: Cleaning up pod-server-0 pod
Jul 22 15:17:56.130: INFO: Waiting for pod pod-server-0 to disappear
Jul 22 15:17:56.140: INFO: Pod pod-server-0 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-1:[80]]
Jul 22 15:17:56.153: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-1:[80]]
STEP: checking client pod connected to the backend 1 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-2 for the service svc-udp
Jul 22 15:18:08.221: INFO: Cleaning up pod-server-1 pod
Jul 22 15:18:08.243: INFO: Waiting for pod pod-server-1 to disappear
Jul 22 15:18:08.249: INFO: Pod pod-server-1 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-2:[80]]
Jul 22 15:18:08.263: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-2:[80]]
STEP: checking client pod connected to the backend 2 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-3 for the service svc-udp
Jul 22 15:18:20.329: INFO: Cleaning up pod-server-2 pod
Jul 22 15:18:20.346: INFO: Waiting for pod pod-server-2 to disappear
Jul 22 15:18:20.363: INFO: Pod pod-server-2 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-3:[80]]
Jul 22 15:18:20.384: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-3:[80]]
STEP: checking client pod connected to the backend 3 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-4 for the service svc-udp
Jul 22 15:18:32.445: INFO: Cleaning up pod-server-3 pod
Jul 22 15:18:32.461: INFO: Waiting for pod pod-server-3 to disappear
Jul 22 15:18:32.468: INFO: Pod pod-server-3 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-4:[80]]
Jul 22 15:18:32.474: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-4:[80]]
STEP: checking client pod connected to the backend 4 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-5 for the service svc-udp
Jul 22 15:18:44.543: INFO: Cleaning up pod-server-4 pod
Jul 22 15:18:44.565: INFO: Waiting for pod pod-server-4 to disappear
Jul 22 15:18:44.581: INFO: Pod pod-server-4 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-5:[80]]
Jul 22 15:18:44.596: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-5:[80]]
STEP: checking client pod connected to the backend 5 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-6 for the service svc-udp
Jul 22 15:18:56.655: INFO: Cleaning up pod-server-5 pod
Jul 22 15:18:56.677: INFO: Waiting for pod pod-server-5 to disappear
Jul 22 15:18:56.690: INFO: Pod pod-server-5 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-6:[80]]
Jul 22 15:18:56.701: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-6:[80]]
STEP: checking client pod connected to the backend 6 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-7 for the service svc-udp
Jul 22 15:19:08.761: INFO: Cleaning up pod-server-6 pod
Jul 22 15:19:08.785: INFO: Waiting for pod pod-server-6 to disappear
Jul 22 15:19:08.798: INFO: Pod pod-server-6 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-7:[80]]
Jul 22 15:19:08.815: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-7:[80]]
STEP: checking client pod connected to the backend 7 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-8 for the service svc-udp
Jul 22 15:19:20.872: INFO: Cleaning up pod-server-7 pod
Jul 22 15:19:20.899: INFO: Waiting for pod pod-server-7 to disappear
Jul 22 15:19:20.924: INFO: Pod pod-server-7 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-8:[80]]
Jul 22 15:19:20.938: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-8:[80]]
STEP: checking client pod connected to the backend 8 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-9 for the service svc-udp
Jul 22 15:19:33.001: INFO: Cleaning up pod-server-8 pod
Jul 22 15:19:33.030: INFO: Waiting for pod pod-server-8 to disappear
Jul 22 15:19:33.049: INFO: Pod pod-server-8 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-9:[80]]
Jul 22 15:19:33.066: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-9:[80]]
STEP: checking client pod connected to the backend 9 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-10 for the service svc-udp
Jul 22 15:19:45.126: INFO: Cleaning up pod-server-9 pod
Jul 22 15:19:45.148: INFO: Waiting for pod pod-server-9 to disappear
Jul 22 15:19:45.158: INFO: Pod pod-server-9 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-10:[80]]
Jul 22 15:19:45.167: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-10:[80]]
STEP: checking client pod connected to the backend 10 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-11 for the service svc-udp
Jul 22 15:19:57.218: INFO: Cleaning up pod-server-10 pod
Jul 22 15:19:57.236: INFO: Waiting for pod pod-server-10 to disappear
Jul 22 15:19:57.245: INFO: Pod pod-server-10 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-11:[80]]
Jul 22 15:19:57.274: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-11:[80]]
STEP: checking client pod connected to the backend 11 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-12 for the service svc-udp
Jul 22 15:20:09.323: INFO: Cleaning up pod-server-11 pod
Jul 22 15:20:09.346: INFO: Waiting for pod pod-server-11 to disappear
Jul 22 15:20:09.354: INFO: Pod pod-server-11 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-12:[80]]
Jul 22 15:20:09.367: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-12:[80]]
STEP: checking client pod connected to the backend 12 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-13 for the service svc-udp
Jul 22 15:20:21.425: INFO: Cleaning up pod-server-12 pod
Jul 22 15:20:21.447: INFO: Waiting for pod pod-server-12 to disappear
Jul 22 15:20:21.459: INFO: Pod pod-server-12 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-13:[80]]
Jul 22 15:20:21.480: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-13:[80]]
STEP: checking client pod connected to the backend 13 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-14 for the service svc-udp
Jul 22 15:20:33.535: INFO: Cleaning up pod-server-13 pod
Jul 22 15:20:33.557: INFO: Waiting for pod pod-server-13 to disappear
Jul 22 15:20:33.571: INFO: Pod pod-server-13 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-14:[80]]
Jul 22 15:20:33.589: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-14:[80]]
STEP: checking client pod connected to the backend 14 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-15 for the service svc-udp
Jul 22 15:20:45.661: INFO: Cleaning up pod-server-14 pod
Jul 22 15:20:45.700: INFO: Waiting for pod pod-server-14 to disappear
Jul 22 15:20:45.709: INFO: Pod pod-server-14 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-15:[80]]
Jul 22 15:20:45.719: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-15:[80]]
STEP: checking client pod connected to the backend 15 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-16 for the service svc-udp
Jul 22 15:20:57.775: INFO: Cleaning up pod-server-15 pod
Jul 22 15:20:57.803: INFO: Waiting for pod pod-server-15 to disappear
Jul 22 15:20:57.810: INFO: Pod pod-server-15 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-16:[80]]
Jul 22 15:20:57.826: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-16:[80]]
STEP: checking client pod connected to the backend 16 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-17 for the service svc-udp
Jul 22 15:21:09.895: INFO: Cleaning up pod-server-16 pod
Jul 22 15:21:09.915: INFO: Waiting for pod pod-server-16 to disappear
Jul 22 15:21:09.925: INFO: Pod pod-server-16 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-17:[80]]
Jul 22 15:21:09.945: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-17:[80]]
STEP: checking client pod connected to the backend 17 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-18 for the service svc-udp
Jul 22 15:21:22.004: INFO: Cleaning up pod-server-17 pod
Jul 22 15:21:22.029: INFO: Waiting for pod pod-server-17 to disappear
Jul 22 15:21:22.038: INFO: Pod pod-server-17 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-18:[80]]
Jul 22 15:21:22.053: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-18:[80]]
STEP: checking client pod connected to the backend 18 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-19 for the service svc-udp
Jul 22 15:21:34.100: INFO: Cleaning up pod-server-18 pod
Jul 22 15:21:34.126: INFO: Waiting for pod pod-server-18 to disappear
Jul 22 15:21:34.141: INFO: Pod pod-server-18 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-19:[80]]
Jul 22 15:21:34.154: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-19:[80]]
STEP: checking client pod connected to the backend 19 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-20 for the service svc-udp
Jul 22 15:21:46.219: INFO: Cleaning up pod-server-19 pod
Jul 22 15:21:46.237: INFO: Waiting for pod pod-server-19 to disappear
Jul 22 15:21:46.250: INFO: Pod pod-server-19 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-20:[80]]
Jul 22 15:21:46.266: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-20:[80]]
STEP: checking client pod connected to the backend 20 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-21 for the service svc-udp
Jul 22 15:21:58.318: INFO: Cleaning up pod-server-20 pod
Jul 22 15:21:58.353: INFO: Waiting for pod pod-server-20 to disappear
Jul 22 15:21:58.364: INFO: Pod pod-server-20 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-21:[80]]
Jul 22 15:21:58.373: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-21:[80]]
STEP: checking client pod connected to the backend 21 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-22 for the service svc-udp
Jul 22 15:22:10.430: INFO: Cleaning up pod-server-21 pod
Jul 22 15:22:10.449: INFO: Waiting for pod pod-server-21 to disappear
Jul 22 15:22:10.460: INFO: Pod pod-server-21 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-22:[80]]
Jul 22 15:22:10.472: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-22:[80]]
STEP: checking client pod connected to the backend 22 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-23 for the service svc-udp
Jul 22 15:22:22.532: INFO: Cleaning up pod-server-22 pod
Jul 22 15:22:22.551: INFO: Waiting for pod pod-server-22 to disappear
Jul 22 15:22:22.557: INFO: Pod pod-server-22 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-23:[80]]
Jul 22 15:22:22.567: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-23:[80]]
STEP: checking client pod connected to the backend 23 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-24 for the service svc-udp
Jul 22 15:22:34.630: INFO: Cleaning up pod-server-23 pod
Jul 22 15:22:34.648: INFO: Waiting for pod pod-server-23 to disappear
Jul 22 15:22:34.665: INFO: Pod pod-server-23 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-24:[80]]
Jul 22 15:22:34.681: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-24:[80]]
STEP: checking client pod connected to the backend 24 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-25 for the service svc-udp
Jul 22 15:22:46.736: INFO: Cleaning up pod-server-24 pod
Jul 22 15:22:46.772: INFO: Waiting for pod pod-server-24 to disappear
Jul 22 15:22:46.784: INFO: Pod pod-server-24 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-25:[80]]
Jul 22 15:22:46.802: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-25:[80]]
STEP: checking client pod connected to the backend 25 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-26 for the service svc-udp
Jul 22 15:22:58.858: INFO: Cleaning up pod-server-25 pod
Jul 22 15:22:58.882: INFO: Waiting for pod pod-server-25 to disappear
Jul 22 15:22:58.890: INFO: Pod pod-server-25 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-26:[80]]
Jul 22 15:22:58.915: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-26:[80]]
STEP: checking client pod connected to the backend 26 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-27 for the service svc-udp
Jul 22 15:23:10.989: INFO: Cleaning up pod-server-26 pod
Jul 22 15:23:11.008: INFO: Waiting for pod pod-server-26 to disappear
Jul 22 15:23:11.013: INFO: Pod pod-server-26 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-27:[80]]
Jul 22 15:23:11.020: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-27:[80]]
STEP: checking client pod connected to the backend 27 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-28 for the service svc-udp
Jul 22 15:23:23.074: INFO: Cleaning up pod-server-27 pod
Jul 22 15:23:23.109: INFO: Waiting for pod pod-server-27 to disappear
Jul 22 15:23:23.124: INFO: Pod pod-server-27 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-28:[80]]
Jul 22 15:23:23.145: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-28:[80]]
STEP: checking client pod connected to the backend 28 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-29 for the service svc-udp
Jul 22 15:23:35.197: INFO: Cleaning up pod-server-28 pod
Jul 22 15:23:35.221: INFO: Waiting for pod pod-server-28 to disappear
Jul 22 15:23:35.227: INFO: Pod pod-server-28 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-29:[80]]
Jul 22 15:23:35.238: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-29:[80]]
STEP: checking client pod connected to the backend 29 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-30 for the service svc-udp
Jul 22 15:23:47.308: INFO: Cleaning up pod-server-29 pod
Jul 22 15:23:47.331: INFO: Waiting for pod pod-server-29 to disappear
Jul 22 15:23:47.337: INFO: Pod pod-server-29 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-30:[80]]
Jul 22 15:23:47.348: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-30:[80]]
STEP: checking client pod connected to the backend 30 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-31 for the service svc-udp
Jul 22 15:23:59.420: INFO: Cleaning up pod-server-30 pod
Jul 22 15:23:59.450: INFO: Waiting for pod pod-server-30 to disappear
Jul 22 15:23:59.463: INFO: Pod pod-server-30 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-31:[80]]
Jul 22 15:23:59.475: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-31:[80]]
STEP: checking client pod connected to the backend 31 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-32 for the service svc-udp
Jul 22 15:24:11.541: INFO: Cleaning up pod-server-31 pod
Jul 22 15:24:11.569: INFO: Waiting for pod pod-server-31 to disappear
Jul 22 15:24:11.583: INFO: Pod pod-server-31 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-32:[80]]
Jul 22 15:24:11.605: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-32:[80]]
STEP: checking client pod connected to the backend 32 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-33 for the service svc-udp
Jul 22 15:24:23.682: INFO: Cleaning up pod-server-32 pod
Jul 22 15:24:23.712: INFO: Waiting for pod pod-server-32 to disappear
Jul 22 15:24:23.722: INFO: Pod pod-server-32 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-33:[80]]
Jul 22 15:24:23.731: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-33:[80]]
STEP: checking client pod connected to the backend 33 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-34 for the service svc-udp
Jul 22 15:24:35.770: INFO: Cleaning up pod-server-33 pod
Jul 22 15:24:35.797: INFO: Waiting for pod pod-server-33 to disappear
Jul 22 15:24:35.808: INFO: Pod pod-server-33 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-34:[80]]
Jul 22 15:24:35.828: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-34:[80]]
STEP: checking client pod connected to the backend 34 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-35 for the service svc-udp
Jul 22 15:24:47.895: INFO: Cleaning up pod-server-34 pod
Jul 22 15:24:47.923: INFO: Waiting for pod pod-server-34 to disappear
Jul 22 15:24:47.933: INFO: Pod pod-server-34 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-35:[80]]
Jul 22 15:24:47.949: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-35:[80]]
STEP: checking client pod connected to the backend 35 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-36 for the service svc-udp
Jul 22 15:25:00.036: INFO: Cleaning up pod-server-35 pod
Jul 22 15:25:00.052: INFO: Waiting for pod pod-server-35 to disappear
Jul 22 15:25:00.062: INFO: Pod pod-server-35 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-36:[80]]
Jul 22 15:25:00.079: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-36:[80]]
STEP: checking client pod connected to the backend 36 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-37 for the service svc-udp
Jul 22 15:25:12.167: INFO: Cleaning up pod-server-36 pod
Jul 22 15:25:12.195: INFO: Waiting for pod pod-server-36 to disappear
Jul 22 15:25:12.208: INFO: Pod pod-server-36 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-37:[80]]
Jul 22 15:25:12.218: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-37:[80]]
STEP: checking client pod connected to the backend 37 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-38 for the service svc-udp
Jul 22 15:25:24.281: INFO: Cleaning up pod-server-37 pod
Jul 22 15:25:24.294: INFO: Waiting for pod pod-server-37 to disappear
Jul 22 15:25:24.307: INFO: Pod pod-server-37 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-38:[80]]
Jul 22 15:25:24.328: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-38:[80]]
STEP: checking client pod connected to the backend 38 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-39 for the service svc-udp
Jul 22 15:25:36.394: INFO: Cleaning up pod-server-38 pod
Jul 22 15:25:36.414: INFO: Waiting for pod pod-server-38 to disappear
Jul 22 15:25:36.426: INFO: Pod pod-server-38 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-39:[80]]
Jul 22 15:25:36.450: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-39:[80]]
STEP: checking client pod connected to the backend 39 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-40 for the service svc-udp
Jul 22 15:25:48.512: INFO: Cleaning up pod-server-39 pod
Jul 22 15:25:48.526: INFO: Waiting for pod pod-server-39 to disappear
Jul 22 15:25:48.545: INFO: Pod pod-server-39 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-40:[80]]
Jul 22 15:25:48.569: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-40:[80]]
STEP: checking client pod connected to the backend 40 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-41 for the service svc-udp
Jul 22 15:26:00.626: INFO: Cleaning up pod-server-40 pod
Jul 22 15:26:00.660: INFO: Waiting for pod pod-server-40 to disappear
Jul 22 15:26:00.670: INFO: Pod pod-server-40 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-41:[80]]
Jul 22 15:26:00.682: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-41:[80]]
STEP: checking client pod connected to the backend 41 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-42 for the service svc-udp
Jul 22 15:26:17.752: INFO: Cleaning up pod-server-41 pod
Jul 22 15:26:17.792: INFO: Waiting for pod pod-server-41 to disappear
Jul 22 15:26:17.809: INFO: Pod pod-server-41 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-42:[80]]
Jul 22 15:26:17.828: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-42:[80]]
STEP: checking client pod connected to the backend 42 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-43 for the service svc-udp
Jul 22 15:26:29.908: INFO: Cleaning up pod-server-42 pod
Jul 22 15:26:29.930: INFO: Waiting for pod pod-server-42 to disappear
Jul 22 15:26:29.938: INFO: Pod pod-server-42 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-43:[80]]
Jul 22 15:26:29.948: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-43:[80]]
STEP: checking client pod connected to the backend 43 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-44 for the service svc-udp
Jul 22 15:26:42.024: INFO: Cleaning up pod-server-43 pod
Jul 22 15:26:42.054: INFO: Waiting for pod pod-server-43 to disappear
Jul 22 15:26:42.060: INFO: Pod pod-server-43 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-44:[80]]
Jul 22 15:26:42.081: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-44:[80]]
STEP: checking client pod connected to the backend 44 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-45 for the service svc-udp
Jul 22 15:26:54.156: INFO: Cleaning up pod-server-44 pod
Jul 22 15:26:54.185: INFO: Waiting for pod pod-server-44 to disappear
Jul 22 15:26:54.233: INFO: Pod pod-server-44 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-45:[80]]
Jul 22 15:26:54.270: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-45:[80]]
STEP: checking client pod connected to the backend 45 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-46 for the service svc-udp
Jul 22 15:27:06.419: INFO: Cleaning up pod-server-45 pod
Jul 22 15:27:06.440: INFO: Waiting for pod pod-server-45 to disappear
Jul 22 15:27:06.453: INFO: Pod pod-server-45 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-46:[80]]
Jul 22 15:27:06.468: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-46:[80]]
STEP: checking client pod connected to the backend 46 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-47 for the service svc-udp
Jul 22 15:27:18.525: INFO: Cleaning up pod-server-46 pod
Jul 22 15:27:18.540: INFO: Waiting for pod pod-server-46 to disappear
Jul 22 15:27:18.546: INFO: Pod pod-server-46 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-47:[80]]
Jul 22 15:27:18.570: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-47:[80]]
STEP: checking client pod connected to the backend 47 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-48 for the service svc-udp
Jul 22 15:27:30.639: INFO: Cleaning up pod-server-47 pod
Jul 22 15:27:30.664: INFO: Waiting for pod pod-server-47 to disappear
Jul 22 15:27:30.681: INFO: Pod pod-server-47 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-48:[80]]
Jul 22 15:27:30.696: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-48:[80]]
STEP: checking client pod connected to the backend 48 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-49 for the service svc-udp
Jul 22 15:27:47.766: INFO: Cleaning up pod-server-48 pod
Jul 22 15:27:47.787: INFO: Waiting for pod pod-server-48 to disappear
Jul 22 15:27:47.797: INFO: Pod pod-server-48 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-49:[80]]
Jul 22 15:27:47.819: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-49:[80]]
STEP: checking client pod connected to the backend 49 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-50 for the service svc-udp
Jul 22 15:27:59.898: INFO: Cleaning up pod-server-49 pod
Jul 22 15:27:59.924: INFO: Waiting for pod pod-server-49 to disappear
Jul 22 15:27:59.933: INFO: Pod pod-server-49 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-50:[80]]
Jul 22 15:27:59.955: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-50:[80]]
STEP: checking client pod connected to the backend 50 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-51 for the service svc-udp
Jul 22 15:28:12.021: INFO: Cleaning up pod-server-50 pod
Jul 22 15:28:12.041: INFO: Waiting for pod pod-server-50 to disappear
Jul 22 15:28:12.049: INFO: Pod pod-server-50 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-51:[80]]
Jul 22 15:28:12.059: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-51:[80]]
STEP: checking client pod connected to the backend 51 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-52 for the service svc-udp
Jul 22 15:28:24.128: INFO: Cleaning up pod-server-51 pod
Jul 22 15:28:24.145: INFO: Waiting for pod pod-server-51 to disappear
Jul 22 15:28:24.158: INFO: Pod pod-server-51 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-52:[80]]
Jul 22 15:28:24.168: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-52:[80]]
STEP: checking client pod connected to the backend 52 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-53 for the service svc-udp
Jul 22 15:28:36.230: INFO: Cleaning up pod-server-52 pod
Jul 22 15:28:36.249: INFO: Waiting for pod pod-server-52 to disappear
Jul 22 15:28:36.276: INFO: Pod pod-server-52 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-53:[80]]
Jul 22 15:28:36.289: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-53:[80]]
STEP: checking client pod connected to the backend 53 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-54 for the service svc-udp
Jul 22 15:28:48.368: INFO: Cleaning up pod-server-53 pod
Jul 22 15:28:48.397: INFO: Waiting for pod pod-server-53 to disappear
Jul 22 15:28:48.404: INFO: Pod pod-server-53 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-54:[80]]
Jul 22 15:28:48.415: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-54:[80]]
STEP: checking client pod connected to the backend 54 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-55 for the service svc-udp
Jul 22 15:29:00.481: INFO: Cleaning up pod-server-54 pod
Jul 22 15:29:00.502: INFO: Waiting for pod pod-server-54 to disappear
Jul 22 15:29:00.512: INFO: Pod pod-server-54 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-55:[80]]
Jul 22 15:29:00.523: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-55:[80]]
STEP: checking client pod connected to the backend 55 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-56 for the service svc-udp
Jul 22 15:29:12.578: INFO: Cleaning up pod-server-55 pod
Jul 22 15:29:12.608: INFO: Waiting for pod pod-server-55 to disappear
Jul 22 15:29:12.619: INFO: Pod pod-server-55 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-56:[80]]
Jul 22 15:29:12.630: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-56:[80]]
STEP: checking client pod connected to the backend 56 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-57 for the service svc-udp
Jul 22 15:29:24.699: INFO: Cleaning up pod-server-56 pod
Jul 22 15:29:24.714: INFO: Waiting for pod pod-server-56 to disappear
Jul 22 15:29:24.726: INFO: Pod pod-server-56 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-57:[80]]
Jul 22 15:29:24.740: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-57:[80]]
STEP: checking client pod connected to the backend 57 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-58 for the service svc-udp
Jul 22 15:29:36.800: INFO: Cleaning up pod-server-57 pod
Jul 22 15:29:36.816: INFO: Waiting for pod pod-server-57 to disappear
Jul 22 15:29:36.830: INFO: Pod pod-server-57 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-58:[80]]
Jul 22 15:29:36.843: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-58:[80]]
STEP: checking client pod connected to the backend 58 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-59 for the service svc-udp
Jul 22 15:29:48.917: INFO: Cleaning up pod-server-58 pod
Jul 22 15:29:48.953: INFO: Waiting for pod pod-server-58 to disappear
Jul 22 15:29:48.974: INFO: Pod pod-server-58 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-59:[80]]
Jul 22 15:29:48.985: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-59:[80]]
STEP: checking client pod connected to the backend 59 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-60 for the service svc-udp
Jul 22 15:30:01.054: INFO: Cleaning up pod-server-59 pod
Jul 22 15:30:01.088: INFO: Waiting for pod pod-server-59 to disappear
Jul 22 15:30:01.098: INFO: Pod pod-server-59 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-60:[80]]
Jul 22 15:30:01.117: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-60:[80]]
STEP: checking client pod connected to the backend 60 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-61 for the service svc-udp
Jul 22 15:30:13.192: INFO: Cleaning up pod-server-60 pod
Jul 22 15:30:13.212: INFO: Waiting for pod pod-server-60 to disappear
Jul 22 15:30:13.221: INFO: Pod pod-server-60 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-61:[80]]
Jul 22 15:30:13.242: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-61:[80]]
STEP: checking client pod connected to the backend 61 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-62 for the service svc-udp
Jul 22 15:30:25.300: INFO: Cleaning up pod-server-61 pod
Jul 22 15:30:25.321: INFO: Waiting for pod pod-server-61 to disappear
Jul 22 15:30:25.331: INFO: Pod pod-server-61 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-62:[80]]
Jul 22 15:30:25.340: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-62:[80]]
STEP: checking client pod connected to the backend 62 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-63 for the service svc-udp
Jul 22 15:30:37.414: INFO: Cleaning up pod-server-62 pod
Jul 22 15:30:37.439: INFO: Waiting for pod pod-server-62 to disappear
Jul 22 15:30:37.454: INFO: Pod pod-server-62 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-63:[80]]
Jul 22 15:30:37.465: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-63:[80]]
STEP: checking client pod connected to the backend 63 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-64 for the service svc-udp
Jul 22 15:30:49.551: INFO: Cleaning up pod-server-63 pod
Jul 22 15:30:49.577: INFO: Waiting for pod pod-server-63 to disappear
Jul 22 15:30:49.585: INFO: Pod pod-server-63 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-64:[80]]
Jul 22 15:30:49.606: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-64:[80]]
STEP: checking client pod connected to the backend 64 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-65 for the service svc-udp
Jul 22 15:31:01.690: INFO: Cleaning up pod-server-64 pod
Jul 22 15:31:01.705: INFO: Waiting for pod pod-server-64 to disappear
Jul 22 15:31:01.714: INFO: Pod pod-server-64 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-65:[80]]
Jul 22 15:31:01.722: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-65:[80]]
STEP: checking client pod connected to the backend 65 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-66 for the service svc-udp
Jul 22 15:31:13.805: INFO: Cleaning up pod-server-65 pod
Jul 22 15:31:13.827: INFO: Waiting for pod pod-server-65 to disappear
Jul 22 15:31:13.832: INFO: Pod pod-server-65 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-66:[80]]
Jul 22 15:31:13.842: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-66:[80]]
STEP: checking client pod connected to the backend 66 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-67 for the service svc-udp
Jul 22 15:31:25.917: INFO: Cleaning up pod-server-66 pod
Jul 22 15:31:25.942: INFO: Waiting for pod pod-server-66 to disappear
Jul 22 15:31:25.950: INFO: Pod pod-server-66 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-67:[80]]
Jul 22 15:31:25.967: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-67:[80]]
STEP: checking client pod connected to the backend 67 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-68 for the service svc-udp
Jul 22 15:31:38.024: INFO: Cleaning up pod-server-67 pod
Jul 22 15:31:38.050: INFO: Waiting for pod pod-server-67 to disappear
Jul 22 15:31:38.061: INFO: Pod pod-server-67 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-68:[80]]
Jul 22 15:31:38.079: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-68:[80]]
STEP: checking client pod connected to the backend 68 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-69 for the service svc-udp
Jul 22 15:31:50.143: INFO: Cleaning up pod-server-68 pod
Jul 22 15:31:50.170: INFO: Waiting for pod pod-server-68 to disappear
Jul 22 15:31:50.183: INFO: Pod pod-server-68 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-69:[80]]
Jul 22 15:31:50.193: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-69:[80]]
STEP: checking client pod connected to the backend 69 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-70 for the service svc-udp
Jul 22 15:32:02.264: INFO: Cleaning up pod-server-69 pod
Jul 22 15:32:02.282: INFO: Waiting for pod pod-server-69 to disappear
Jul 22 15:32:02.289: INFO: Pod pod-server-69 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-70:[80]]
Jul 22 15:32:02.304: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-70:[80]]
STEP: checking client pod connected to the backend 70 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-71 for the service svc-udp
Jul 22 15:32:14.400: INFO: Cleaning up pod-server-70 pod
Jul 22 15:32:14.420: INFO: Waiting for pod pod-server-70 to disappear
Jul 22 15:32:14.429: INFO: Pod pod-server-70 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-71:[80]]
Jul 22 15:32:14.441: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-71:[80]]
STEP: checking client pod connected to the backend 71 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-72 for the service svc-udp
Jul 22 15:32:26.511: INFO: Cleaning up pod-server-71 pod
Jul 22 15:32:26.533: INFO: Waiting for pod pod-server-71 to disappear
Jul 22 15:32:26.550: INFO: Pod pod-server-71 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-72:[80]]
Jul 22 15:32:26.570: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-72:[80]]
STEP: checking client pod connected to the backend 72 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-73 for the service svc-udp
Jul 22 15:32:38.616: INFO: Cleaning up pod-server-72 pod
Jul 22 15:32:38.631: INFO: Waiting for pod pod-server-72 to disappear
Jul 22 15:32:38.638: INFO: Pod pod-server-72 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-73:[80]]
Jul 22 15:32:38.657: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-73:[80]]
STEP: checking client pod connected to the backend 73 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-74 for the service svc-udp
Jul 22 15:32:50.738: INFO: Cleaning up pod-server-73 pod
Jul 22 15:32:50.765: INFO: Waiting for pod pod-server-73 to disappear
Jul 22 15:32:50.774: INFO: Pod pod-server-73 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-74:[80]]
Jul 22 15:32:50.786: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-74:[80]]
STEP: checking client pod connected to the backend 74 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-75 for the service svc-udp
Jul 22 15:33:07.848: INFO: Cleaning up pod-server-74 pod
Jul 22 15:33:07.868: INFO: Waiting for pod pod-server-74 to disappear
Jul 22 15:33:07.872: INFO: Pod pod-server-74 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-75:[80]]
Jul 22 15:33:07.894: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-75:[80]]
STEP: checking client pod connected to the backend 75 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-76 for the service svc-udp
Jul 22 15:33:19.950: INFO: Cleaning up pod-server-75 pod
Jul 22 15:33:19.974: INFO: Waiting for pod pod-server-75 to disappear
Jul 22 15:33:19.985: INFO: Pod pod-server-75 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-76:[80]]
Jul 22 15:33:19.999: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-76:[80]]
STEP: checking client pod connected to the backend 76 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-77 for the service svc-udp
Jul 22 15:33:32.060: INFO: Cleaning up pod-server-76 pod
Jul 22 15:33:32.091: INFO: Waiting for pod pod-server-76 to disappear
Jul 22 15:33:32.099: INFO: Pod pod-server-76 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-77:[80]]
Jul 22 15:33:32.116: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-77:[80]]
STEP: checking client pod connected to the backend 77 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-78 for the service svc-udp
Jul 22 15:33:44.196: INFO: Cleaning up pod-server-77 pod
Jul 22 15:33:44.224: INFO: Waiting for pod pod-server-77 to disappear
Jul 22 15:33:44.231: INFO: Pod pod-server-77 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-78:[80]]
Jul 22 15:33:44.246: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-78:[80]]
STEP: checking client pod connected to the backend 78 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-79 for the service svc-udp
Jul 22 15:33:56.300: INFO: Cleaning up pod-server-78 pod
Jul 22 15:33:56.325: INFO: Waiting for pod pod-server-78 to disappear
Jul 22 15:33:56.332: INFO: Pod pod-server-78 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-79:[80]]
Jul 22 15:33:56.342: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-79:[80]]
STEP: checking client pod connected to the backend 79 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-80 for the service svc-udp
Jul 22 15:34:08.400: INFO: Cleaning up pod-server-79 pod
Jul 22 15:34:08.423: INFO: Waiting for pod pod-server-79 to disappear
Jul 22 15:34:08.435: INFO: Pod pod-server-79 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-80:[80]]
Jul 22 15:34:08.451: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-80:[80]]
STEP: checking client pod connected to the backend 80 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-81 for the service svc-udp
Jul 22 15:34:20.534: INFO: Cleaning up pod-server-80 pod
Jul 22 15:34:20.554: INFO: Waiting for pod pod-server-80 to disappear
Jul 22 15:34:20.570: INFO: Pod pod-server-80 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-81:[80]]
Jul 22 15:34:20.586: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-81:[80]]
STEP: checking client pod connected to the backend 81 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-82 for the service svc-udp
Jul 22 15:34:32.651: INFO: Cleaning up pod-server-81 pod
Jul 22 15:34:32.670: INFO: Waiting for pod pod-server-81 to disappear
Jul 22 15:34:32.687: INFO: Pod pod-server-81 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-82:[80]]
Jul 22 15:34:32.702: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-82:[80]]
STEP: checking client pod connected to the backend 82 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-83 for the service svc-udp
Jul 22 15:34:44.785: INFO: Cleaning up pod-server-82 pod
Jul 22 15:34:44.811: INFO: Waiting for pod pod-server-82 to disappear
Jul 22 15:34:44.816: INFO: Pod pod-server-82 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-83:[80]]
Jul 22 15:34:44.826: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-83:[80]]
STEP: checking client pod connected to the backend 83 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-84 for the service svc-udp
Jul 22 15:34:56.907: INFO: Cleaning up pod-server-83 pod
Jul 22 15:34:56.930: INFO: Waiting for pod pod-server-83 to disappear
Jul 22 15:34:56.943: INFO: Pod pod-server-83 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-84:[80]]
Jul 22 15:34:56.957: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-84:[80]]
STEP: checking client pod connected to the backend 84 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-85 for the service svc-udp
Jul 22 15:35:09.014: INFO: Cleaning up pod-server-84 pod
Jul 22 15:35:09.055: INFO: Waiting for pod pod-server-84 to disappear
Jul 22 15:35:09.081: INFO: Pod pod-server-84 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-85:[80]]
Jul 22 15:35:09.109: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-85:[80]]
STEP: checking client pod connected to the backend 85 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-86 for the service svc-udp
Jul 22 15:35:21.176: INFO: Cleaning up pod-server-85 pod
Jul 22 15:35:21.208: INFO: Waiting for pod pod-server-85 to disappear
Jul 22 15:35:21.229: INFO: Pod pod-server-85 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-86:[80]]
Jul 22 15:35:21.242: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-86:[80]]
STEP: checking client pod connected to the backend 86 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-87 for the service svc-udp
Jul 22 15:35:33.374: INFO: Cleaning up pod-server-86 pod
Jul 22 15:35:33.409: INFO: Waiting for pod pod-server-86 to disappear
Jul 22 15:35:33.422: INFO: Pod pod-server-86 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-87:[80]]
Jul 22 15:35:33.431: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-87:[80]]
STEP: checking client pod connected to the backend 87 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-88 for the service svc-udp
Jul 22 15:35:45.508: INFO: Cleaning up pod-server-87 pod
Jul 22 15:35:45.529: INFO: Waiting for pod pod-server-87 to disappear
Jul 22 15:35:45.538: INFO: Pod pod-server-87 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-88:[80]]
Jul 22 15:35:45.555: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-88:[80]]
STEP: checking client pod connected to the backend 88 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-89 for the service svc-udp
Jul 22 15:35:57.628: INFO: Cleaning up pod-server-88 pod
Jul 22 15:35:57.647: INFO: Waiting for pod pod-server-88 to disappear
Jul 22 15:35:57.656: INFO: Pod pod-server-88 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-89:[80]]
Jul 22 15:35:57.670: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-89:[80]]
STEP: checking client pod connected to the backend 89 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-90 for the service svc-udp
Jul 22 15:36:09.758: INFO: Cleaning up pod-server-89 pod
Jul 22 15:36:09.804: INFO: Waiting for pod pod-server-89 to disappear
Jul 22 15:36:09.816: INFO: Pod pod-server-89 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-90:[80]]
Jul 22 15:36:09.833: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-90:[80]]
STEP: checking client pod connected to the backend 90 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-91 for the service svc-udp
Jul 22 15:36:21.918: INFO: Cleaning up pod-server-90 pod
Jul 22 15:36:21.940: INFO: Waiting for pod pod-server-90 to disappear
Jul 22 15:36:21.951: INFO: Pod pod-server-90 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-91:[80]]
Jul 22 15:36:21.959: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-91:[80]]
STEP: checking client pod connected to the backend 91 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-92 for the service svc-udp
Jul 22 15:36:34.047: INFO: Cleaning up pod-server-91 pod
Jul 22 15:36:34.068: INFO: Waiting for pod pod-server-91 to disappear
Jul 22 15:36:34.088: INFO: Pod pod-server-91 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-92:[80]]
Jul 22 15:36:34.106: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-92:[80]]
STEP: checking client pod connected to the backend 92 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-93 for the service svc-udp
Jul 22 15:36:46.229: INFO: Cleaning up pod-server-92 pod
Jul 22 15:36:46.249: INFO: Waiting for pod pod-server-92 to disappear
Jul 22 15:36:46.261: INFO: Pod pod-server-92 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-93:[80]]
Jul 22 15:36:46.272: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-93:[80]]
STEP: checking client pod connected to the backend 93 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-94 for the service svc-udp
Jul 22 15:36:58.364: INFO: Cleaning up pod-server-93 pod
Jul 22 15:36:58.390: INFO: Waiting for pod pod-server-93 to disappear
Jul 22 15:36:58.394: INFO: Pod pod-server-93 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-94:[80]]
Jul 22 15:36:58.407: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-94:[80]]
STEP: checking client pod connected to the backend 94 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-95 for the service svc-udp
Jul 22 15:37:10.486: INFO: Cleaning up pod-server-94 pod
Jul 22 15:37:10.513: INFO: Waiting for pod pod-server-94 to disappear
Jul 22 15:37:10.526: INFO: Pod pod-server-94 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-95:[80]]
Jul 22 15:37:10.536: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-95:[80]]
STEP: checking client pod connected to the backend 95 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-96 for the service svc-udp
Jul 22 15:37:22.628: INFO: Cleaning up pod-server-95 pod
Jul 22 15:37:22.651: INFO: Waiting for pod pod-server-95 to disappear
Jul 22 15:37:22.660: INFO: Pod pod-server-95 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-96:[80]]
Jul 22 15:37:22.668: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-96:[80]]
STEP: checking client pod connected to the backend 96 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-97 for the service svc-udp
Jul 22 15:37:34.777: INFO: Cleaning up pod-server-96 pod
Jul 22 15:37:34.805: INFO: Waiting for pod pod-server-96 to disappear
Jul 22 15:37:34.816: INFO: Pod pod-server-96 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-97:[80]]
Jul 22 15:37:34.832: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-97:[80]]
STEP: checking client pod connected to the backend 97 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-98 for the service svc-udp
Jul 22 15:37:46.908: INFO: Cleaning up pod-server-97 pod
Jul 22 15:37:46.927: INFO: Waiting for pod pod-server-97 to disappear
Jul 22 15:37:46.940: INFO: Pod pod-server-97 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-98:[80]]
Jul 22 15:37:46.960: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-98:[80]]
STEP: checking client pod connected to the backend 98 on Node IP 172.24.0.5
STEP: creating a backend pod pod-server-99 for the service svc-udp
Jul 22 15:37:59.042: INFO: Cleaning up pod-server-98 pod
Jul 22 15:37:59.055: INFO: Waiting for pod pod-server-98 to disappear
Jul 22 15:37:59.077: INFO: Pod pod-server-98 no longer exists
STEP: waiting up to 3m0s for service svc-udp in namespace conntrack-1620 to expose endpoints map[pod-server-99:[80]]
Jul 22 15:37:59.088: INFO: successfully validated that service svc-udp in namespace conntrack-1620 exposes endpoints map[pod-server-99:[80]]
STEP: checking client pod connected to the backend 99 on Node IP 172.24.0.5
Jul 22 15:38:09.127: INFO: Running '/usr/local/bin/kubectl --server=https://127.0.0.1:50395 --kubeconfig=/Users/mfenwick/.kube/config exec --namespace=kube-system kube-proxy-p2chw -- /bin/sh -x -c conntrack -L'
Jul 22 15:38:09.868: INFO: stderr: "+ conntrack -L\nconntrack v1.4.5 (conntrack-tools): 13 flow entries have been shown.\n"
Jul 22 15:38:09.868: INFO: stdout: "udp      17 29 src=172.24.0.2 dst=192.168.65.2 sport=52913 dport=53 src=127.0.0.11 dst=172.24.0.2 sport=43274 dport=52913 mark=0 use=1\nudp      17 9 src=172.24.0.2 dst=192.168.65.2 sport=41963 dport=53 src=127.0.0.11 dst=172.24.0.2 sport=43274 dport=41963 mark=0 use=1\nudp      17 9 src=172.24.0.2 dst=192.168.65.2 sport=49880 dport=53 src=127.0.0.11 dst=172.24.0.2 sport=43274 dport=49880 mark=0 use=1\nudp      17 176 src=10.244.2.10 dst=172.24.0.5 sport=12345 dport=31187 src=172.24.0.5 dst=172.24.0.2 sport=31187 dport=12345 [ASSURED] mark=0 use=1\nudp      17 19 src=172.24.0.2 dst=192.168.65.2 sport=47434 dport=53 src=127.0.0.11 dst=172.24.0.2 sport=43274 dport=47434 mark=0 use=1\nudp      17 19 src=172.24.0.2 dst=192.168.65.2 sport=54538 dport=53 src=127.0.0.11 dst=172.24.0.2 sport=43274 dport=54538 mark=0 use=1\nudp      17 29 src=172.24.0.2 dst=192.168.65.2 sport=50394 dport=53 src=127.0.0.11 dst=172.24.0.2 sport=43274 dport=50394 mark=0 use=1\ntcp      6 86399 ESTABLISHED src=172.24.0.2 dst=172.24.0.6 sport=51462 dport=6443 src=172.24.0.6 dst=172.24.0.2 sport=6443 dport=51462 [ASSURED] mark=0 use=1\ntcp      6 86399 ESTABLISHED src=172.24.0.6 dst=172.24.0.2 sport=37216 dport=10250 src=172.24.0.2 dst=172.24.0.6 sport=10250 dport=37216 [ASSURED] mark=0 use=1\ntcp      6 86399 ESTABLISHED src=172.24.0.2 dst=172.24.0.6 sport=51510 dport=6443 src=172.24.0.6 dst=172.24.0.2 sport=6443 dport=51510 [ASSURED] mark=0 use=1\ntcp      6 86399 ESTABLISHED src=172.24.0.6 dst=172.24.0.2 sport=44110 dport=10250 src=172.24.0.2 dst=172.24.0.6 sport=10250 dport=44110 [ASSURED] mark=0 use=1\ntcp      6 86399 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=50642 dport=46807 src=127.0.0.1 dst=127.0.0.1 sport=46807 dport=50642 [ASSURED] mark=0 use=1\ntcp      6 86390 ESTABLISHED src=172.24.0.2 dst=10.96.0.1 sport=39608 dport=443 src=172.24.0.6 dst=172.24.0.2 sport=6443 dport=4547 [ASSURED] mark=0 use=1\n"
Jul 22 15:38:09.868: INFO: conntrack table of node three-node-worker: udp      17 29 src=172.24.0.2 dst=192.168.65.2 sport=52913 dport=53 src=127.0.0.11 dst=172.24.0.2 sport=43274 dport=52913 mark=0 use=1
udp      17 9 src=172.24.0.2 dst=192.168.65.2 sport=41963 dport=53 src=127.0.0.11 dst=172.24.0.2 sport=43274 dport=41963 mark=0 use=1
udp      17 9 src=172.24.0.2 dst=192.168.65.2 sport=49880 dport=53 src=127.0.0.11 dst=172.24.0.2 sport=43274 dport=49880 mark=0 use=1
udp      17 176 src=10.244.2.10 dst=172.24.0.5 sport=12345 dport=31187 src=172.24.0.5 dst=172.24.0.2 sport=31187 dport=12345 [ASSURED] mark=0 use=1
udp      17 19 src=172.24.0.2 dst=192.168.65.2 sport=47434 dport=53 src=127.0.0.11 dst=172.24.0.2 sport=43274 dport=47434 mark=0 use=1
udp      17 19 src=172.24.0.2 dst=192.168.65.2 sport=54538 dport=53 src=127.0.0.11 dst=172.24.0.2 sport=43274 dport=54538 mark=0 use=1
udp      17 29 src=172.24.0.2 dst=192.168.65.2 sport=50394 dport=53 src=127.0.0.11 dst=172.24.0.2 sport=43274 dport=50394 mark=0 use=1
tcp      6 86399 ESTABLISHED src=172.24.0.2 dst=172.24.0.6 sport=51462 dport=6443 src=172.24.0.6 dst=172.24.0.2 sport=6443 dport=51462 [ASSURED] mark=0 use=1
tcp      6 86399 ESTABLISHED src=172.24.0.6 dst=172.24.0.2 sport=37216 dport=10250 src=172.24.0.2 dst=172.24.0.6 sport=10250 dport=37216 [ASSURED] mark=0 use=1
tcp      6 86399 ESTABLISHED src=172.24.0.2 dst=172.24.0.6 sport=51510 dport=6443 src=172.24.0.6 dst=172.24.0.2 sport=6443 dport=51510 [ASSURED] mark=0 use=1
tcp      6 86399 ESTABLISHED src=172.24.0.6 dst=172.24.0.2 sport=44110 dport=10250 src=172.24.0.2 dst=172.24.0.6 sport=10250 dport=44110 [ASSURED] mark=0 use=1
tcp      6 86399 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=50642 dport=46807 src=127.0.0.1 dst=127.0.0.1 sport=46807 dport=50642 [ASSURED] mark=0 use=1
tcp      6 86390 ESTABLISHED src=172.24.0.2 dst=10.96.0.1 sport=39608 dport=443 src=172.24.0.6 dst=172.24.0.2 sport=6443 dport=4547 [ASSURED] mark=0 use=1

Jul 22 15:38:09.868: INFO: Running '/usr/local/bin/kubectl --server=https://127.0.0.1:50395 --kubeconfig=/Users/mfenwick/.kube/config exec --namespace=kube-system kube-proxy-qpxqx -- /bin/sh -x -c conntrack -L'
Jul 22 15:38:10.020: INFO: stderr: "+ conntrack -L\nconntrack v1.4.5 (conntrack-tools): 167 flow entries have been shown.\n"
Jul 22 15:38:10.020: INFO: stdout: "udp      17 18 src=172.24.0.6 dst=192.168.65.2 sport=56199 dport=53 src=127.0.0.11 dst=172.24.0.6 sport=48495 dport=56199 mark=0 use=1\ntcp      6 86395 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56430 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56430 [ASSURED] mark=0 use=1\ntcp      6 86399 ESTABLISHED src=172.24.0.1 dst=172.24.0.6 sport=54154 dport=6443 src=172.24.0.6 dst=172.24.0.1 sport=6443 dport=54154 [ASSURED] mark=0 use=1\ntcp      6 61 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=40326 dport=8181 src=10.244.0.2 dst=10.244.0.1 sport=8181 dport=40326 [ASSURED] mark=0 use=1\ntcp      6 70 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=55376 dport=8080 src=10.244.0.2 dst=10.244.0.1 sport=8080 dport=55376 [ASSURED] mark=0 use=1\ntcp      6 86394 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56362 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56362 [ASSURED] mark=0 use=1\ntcp      6 11 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=40046 dport=8181 src=10.244.0.2 dst=10.244.0.1 sport=8181 dport=40046 [ASSURED] mark=0 use=1\ntcp      6 109 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=51292 dport=8080 src=10.244.0.3 dst=10.244.0.1 sport=8080 dport=51292 [ASSURED] mark=0 use=1\ntcp      6 1 CLOSE src=172.24.0.6 dst=172.24.0.6 sport=44466 dport=6443 src=172.24.0.6 dst=172.24.0.6 sport=6443 dport=44466 [ASSURED] mark=0 use=1\ntcp      6 97 TIME_WAIT src=127.0.0.1 dst=127.0.0.1 sport=39532 dport=2381 src=127.0.0.1 dst=127.0.0.1 sport=2381 dport=39532 [ASSURED] mark=0 use=1\ntcp      6 23 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=45832 dport=8181 src=10.244.0.3 dst=10.244.0.1 sport=8181 dport=45832 [ASSURED] mark=0 use=1\ntcp      6 86393 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56334 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56334 [ASSURED] mark=0 use=1\ntcp      6 86389 ESTABLISHED src=172.24.0.6 dst=172.24.0.6 sport=50946 dport=6443 src=172.24.0.6 dst=172.24.0.6 sport=6443 dport=50946 [ASSURED] mark=0 use=1\ntcp      6 57 TIME_WAIT src=127.0.0.1 dst=127.0.0.1 sport=39308 dport=2381 src=127.0.0.1 dst=127.0.0.1 sport=2381 dport=39308 [ASSURED] mark=0 use=1\ntcp      6 86399 ESTABLISHED src=172.24.0.2 dst=172.24.0.6 sport=51510 dport=6443 src=172.24.0.6 dst=172.24.0.2 sport=6443 dport=51510 [ASSURED] mark=0 use=1\nudp      17 28 src=172.24.0.6 dst=192.168.65.2 sport=33513 dport=53 src=127.0.0.11 dst=172.24.0.6 sport=48495 dport=33513 mark=0 use=1\ntcp      6 86390 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56346 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56346 [ASSURED] mark=0 use=1\ntcp      6 86391 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56344 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56344 [ASSURED] mark=0 use=1\ntcp      6 86394 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56440 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56440 [ASSURED] mark=0 use=2\ntcp      6 86389 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56412 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56412 [ASSURED] mark=0 use=1\ntcp      6 86389 ESTABLISHED src=172.24.0.6 dst=172.24.0.6 sport=34102 dport=2379 src=172.24.0.6 dst=172.24.0.6 sport=2379 dport=34102 [ASSURED] mark=0 use=1\ntcp      6 86389 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56324 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56324 [ASSURED] mark=0 use=1\ntcp      6 86387 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56340 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56340 [ASSURED] mark=0 use=1\ntcp      6 86398 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56380 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56380 [ASSURED] mark=0 use=1\ntcp      6 83 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=46168 dport=8181 src=10.244.0.3 dst=10.244.0.1 sport=8181 dport=46168 [ASSURED] mark=0 use=1\ntcp      6 86399 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56376 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56376 [ASSURED] mark=0 use=1\ntcp      6 91 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=40494 dport=8181 src=10.244.0.2 dst=10.244.0.1 sport=8181 dport=40494 [ASSURED] mark=0 use=1\ntcp      6 1 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=39990 dport=8181 src=10.244.0.2 dst=10.244.0.1 sport=8181 dport=39990 [ASSURED] mark=0 use=1\ntcp      6 86399 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56416 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56416 [ASSURED] mark=0 use=1\ntcp      6 86392 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56372 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56372 [ASSURED] mark=0 use=1\ntcp      6 79 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=51124 dport=8080 src=10.244.0.3 dst=10.244.0.1 sport=8080 dport=51124 [ASSURED] mark=0 use=1\ntcp      6 3 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=45720 dport=8181 src=10.244.0.3 dst=10.244.0.1 sport=8181 dport=45720 [ASSURED] mark=0 use=1\ntcp      6 86399 ESTABLISHED src=172.24.0.5 dst=172.24.0.6 sport=36204 dport=6443 src=172.24.0.6 dst=172.24.0.5 sport=6443 dport=36204 [ASSURED] mark=0 use=1\ntcp      6 86391 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56388 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56388 [ASSURED] mark=0 use=1\ntcp      6 86398 ESTABLISHED src=172.24.0.5 dst=172.24.0.6 sport=36178 dport=6443 src=172.24.0.6 dst=172.24.0.5 sport=6443 dport=36178 [ASSURED] mark=0 use=1\ntcp      6 87 TIME_WAIT src=127.0.0.1 dst=127.0.0.1 sport=39476 dport=2381 src=127.0.0.1 dst=127.0.0.1 sport=2381 dport=39476 [ASSURED] mark=0 use=1\ntcp      6 86397 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56342 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56342 [ASSURED] mark=0 use=1\ntcp      6 17 TIME_WAIT src=127.0.0.1 dst=127.0.0.1 sport=39084 dport=2381 src=127.0.0.1 dst=127.0.0.1 sport=2381 dport=39084 [ASSURED] mark=0 use=1\ntcp      6 86399 ESTABLISHED src=172.24.0.6 dst=172.24.0.6 sport=51150 dport=6443 src=172.24.0.6 dst=172.24.0.6 sport=6443 dport=51150 [ASSURED] mark=0 use=1\ntcp      6 10 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=55040 dport=8080 src=10.244.0.2 dst=10.244.0.1 sport=8080 dport=55040 [ASSURED] mark=0 use=1\ntcp      6 61 TIME_WAIT src=172.24.0.6 dst=172.24.0.6 sport=44186 dport=6443 src=172.24.0.6 dst=172.24.0.6 sport=6443 dport=44186 [ASSURED] mark=0 use=1\ntcp      6 299 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=42870 dport=45379 src=127.0.0.1 dst=127.0.0.1 sport=45379 dport=42870 [ASSURED] mark=0 use=1\ntcp      6 21 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=40102 dport=8181 src=10.244.0.2 dst=10.244.0.1 sport=8181 dport=40102 [ASSURED] mark=0 use=1\ntcp      6 86399 ESTABLISHED src=172.24.0.6 dst=172.24.0.6 sport=51164 dport=6443 src=172.24.0.6 dst=172.24.0.6 sport=6443 dport=51164 [ASSURED] mark=0 use=1\ntcp      6 93 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=46224 dport=8181 src=10.244.0.3 dst=10.244.0.1 sport=8181 dport=46224 [ASSURED] mark=0 use=1\ntcp      6 86399 ESTABLISHED src=172.24.0.1 dst=172.24.0.6 sport=47236 dport=6443 src=172.24.0.6 dst=172.24.0.1 sport=6443 dport=47236 [ASSURED] mark=0 use=1\ntcp      6 30 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=55152 dport=8080 src=10.244.0.2 dst=10.244.0.1 sport=8080 dport=55152 [ASSURED] mark=0 use=1\ntcp      6 86394 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56462 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56462 [ASSURED] mark=0 use=1\ntcp      6 86399 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56450 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56450 [ASSURED] mark=0 use=1\ntcp      6 3 CLOSE src=127.0.0.1 dst=127.0.0.1 sport=52912 dport=10257 src=127.0.0.1 dst=127.0.0.1 sport=10257 dport=52912 [ASSURED] mark=0 use=1\ntcp      6 9 CLOSE src=172.24.0.1 dst=172.24.0.6 sport=54140 dport=6443 src=172.24.0.6 dst=172.24.0.1 sport=6443 dport=54140 [ASSURED] mark=0 use=1\ntcp      6 9 CLOSE src=172.24.0.6 dst=172.24.0.2 sport=44110 dport=10250 src=172.24.0.2 dst=172.24.0.6 sport=10250 dport=44110 [ASSURED] mark=0 use=1\nudp      17 28 src=172.24.0.6 dst=192.168.65.2 sport=50743 dport=53 src=127.0.0.11 dst=172.24.0.6 sport=48495 dport=50743 mark=0 use=1\ntcp      6 99 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=51236 dport=8080 src=10.244.0.3 dst=10.244.0.1 sport=8080 dport=51236 [ASSURED] mark=0 use=1\ntcp      6 86395 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56384 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56384 [ASSURED] mark=0 use=1\ntcp      6 100 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=55544 dport=8080 src=10.244.0.2 dst=10.244.0.1 sport=8080 dport=55544 [ASSURED] mark=0 use=1\ntcp      6 86394 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56442 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56442 [ASSURED] mark=0 use=2\ntcp      6 119 TIME_WAIT src=172.24.0.1 dst=172.24.0.6 sport=54136 dport=6443 src=172.24.0.6 dst=172.24.0.1 sport=6443 dport=54136 [ASSURED] mark=0 use=1\ntcp      6 86399 ESTABLISHED src=10.244.0.4 dst=10.96.0.1 sport=50344 dport=443 src=172.24.0.6 dst=10.244.0.4 sport=6443 dport=50344 [ASSURED] mark=0 use=1\ntcp      6 67 TIME_WAIT src=127.0.0.1 dst=127.0.0.1 sport=39364 dport=2381 src=127.0.0.1 dst=127.0.0.1 sport=2381 dport=39364 [ASSURED] mark=0 use=1\ntcp      6 86398 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56400 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56400 [ASSURED] mark=0 use=1\ntcp      6 86385 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56378 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56378 [ASSURED] mark=0 use=1\ntcp      6 86386 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56390 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56390 [ASSURED] mark=0 use=1\ntcp      6 86393 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56436 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56436 [ASSURED] mark=0 use=1\ntcp      6 86393 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56458 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56458 [ASSURED] mark=0 use=1\ntcp      6 86397 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56456 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56456 [ASSURED] mark=0 use=1\ntcp      6 86386 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56338 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56338 [ASSURED] mark=0 use=1\ntcp      6 33 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=45888 dport=8181 src=10.244.0.3 dst=10.244.0.1 sport=8181 dport=45888 [ASSURED] mark=0 use=1\ntcp      6 86397 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56370 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56370 [ASSURED] mark=0 use=1\ntcp      6 86391 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56402 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56402 [ASSURED] mark=0 use=1\nudp      17 8 src=172.24.0.6 dst=192.168.65.2 sport=39350 dport=53 src=127.0.0.11 dst=172.24.0.6 sport=48495 dport=39350 mark=0 use=1\ntcp      6 86388 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56438 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56438 [ASSURED] mark=0 use=1\ntcp      6 86398 ESTABLISHED src=172.24.0.5 dst=172.24.0.6 sport=26819 dport=6443 src=172.24.0.6 dst=172.24.0.5 sport=6443 dport=26819 [ASSURED] mark=0 use=1\ntcp      6 69 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=51068 dport=8080 src=10.244.0.3 dst=10.244.0.1 sport=8080 dport=51068 [ASSURED] mark=0 use=1\ntcp      6 110 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=55600 dport=8080 src=10.244.0.2 dst=10.244.0.1 sport=8080 dport=55600 [ASSURED] mark=0 use=1\ntcp      6 73 TIME_WAIT src=127.0.0.1 dst=127.0.0.1 sport=52688 dport=10257 src=127.0.0.1 dst=127.0.0.1 sport=10257 dport=52688 [ASSURED] mark=0 use=1\ntcp      6 86399 ESTABLISHED src=172.24.0.6 dst=172.24.0.6 sport=50950 dport=6443 src=172.24.0.6 dst=172.24.0.6 sport=6443 dport=50950 [ASSURED] mark=0 use=1\ntcp      6 119 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=51348 dport=8080 src=10.244.0.3 dst=10.244.0.1 sport=8080 dport=51348 [ASSURED] mark=0 use=1\ntcp      6 51 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=40270 dport=8181 src=10.244.0.2 dst=10.244.0.1 sport=8181 dport=40270 [ASSURED] mark=0 use=1\ntcp      6 86394 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56364 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56364 [ASSURED] mark=0 use=1\ntcp      6 86385 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56386 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56386 [ASSURED] mark=0 use=1\ntcp      6 115 TIME_WAIT src=127.0.0.1 dst=127.0.0.1 sport=45494 dport=10259 src=127.0.0.1 dst=127.0.0.1 sport=10259 dport=45494 [ASSURED] mark=0 use=1\ntcp      6 86390 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56444 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56444 [ASSURED] mark=0 use=1\ntcp      6 53 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=46000 dport=8181 src=10.244.0.3 dst=10.244.0.1 sport=8181 dport=46000 [ASSURED] mark=0 use=1\ntcp      6 86399 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56406 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56406 [ASSURED] mark=0 use=1\ntcp      6 86388 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56424 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56424 [ASSURED] mark=0 use=1\ntcp      6 86392 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56366 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56366 [ASSURED] mark=0 use=1\ntcp      6 86399 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56356 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56356 [ASSURED] mark=0 use=1\ntcp      6 86388 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56418 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56418 [ASSURED] mark=0 use=1\ntcp      6 111 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=40606 dport=8181 src=10.244.0.2 dst=10.244.0.1 sport=8181 dport=40606 [ASSURED] mark=0 use=1\ntcp      6 39 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=50900 dport=8080 src=10.244.0.3 dst=10.244.0.1 sport=8080 dport=50900 [ASSURED] mark=0 use=1\ntcp      6 19 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=50788 dport=8080 src=10.244.0.3 dst=10.244.0.1 sport=8080 dport=50788 [ASSURED] mark=0 use=1\ntcp      6 103 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=46280 dport=8181 src=10.244.0.3 dst=10.244.0.1 sport=8181 dport=46280 [ASSURED] mark=0 use=1\ntcp      6 37 TIME_WAIT src=127.0.0.1 dst=127.0.0.1 sport=39196 dport=2381 src=127.0.0.1 dst=127.0.0.1 sport=2381 dport=39196 [ASSURED] mark=0 use=1\ntcp      6 86399 ESTABLISHED src=10.244.0.3 dst=10.96.0.1 sport=43960 dport=443 src=172.24.0.6 dst=10.244.0.3 sport=6443 dport=43960 [ASSURED] mark=0 use=2\ntcp      6 86397 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56420 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56420 [ASSURED] mark=0 use=1\ntcp      6 40 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=55208 dport=8080 src=10.244.0.2 dst=10.244.0.1 sport=8080 dport=55208 [ASSURED] mark=0 use=1\ntcp      6 86399 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56348 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56348 [ASSURED] mark=0 use=1\ntcp      6 86399 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56414 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56414 [ASSURED] mark=0 use=1\ntcp      6 86395 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56332 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56332 [ASSURED] mark=0 use=1\ntcp      6 63 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=46056 dport=8181 src=10.244.0.3 dst=10.244.0.1 sport=8181 dport=46056 [ASSURED] mark=0 use=1\ntcp      6 60 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=55320 dport=8080 src=10.244.0.2 dst=10.244.0.1 sport=8080 dport=55320 [ASSURED] mark=0 use=1\ntcp      6 101 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=40550 dport=8181 src=10.244.0.2 dst=10.244.0.1 sport=8181 dport=40550 [ASSURED] mark=0 use=1\ntcp      6 20 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=55096 dport=8080 src=10.244.0.2 dst=10.244.0.1 sport=8080 dport=55096 [ASSURED] mark=0 use=1\ntcp      6 86399 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56354 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56354 [ASSURED] mark=0 use=1\ntcp      6 86386 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56426 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56426 [ASSURED] mark=0 use=1\ntcp      6 86395 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56314 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56314 [ASSURED] mark=0 use=1\ntcp      6 86386 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56432 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56432 [ASSURED] mark=0 use=1\ntcp      6 49 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=50956 dport=8080 src=10.244.0.3 dst=10.244.0.1 sport=8080 dport=50956 [ASSURED] mark=0 use=1\ntcp      6 89 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=51180 dport=8080 src=10.244.0.3 dst=10.244.0.1 sport=8080 dport=51180 [ASSURED] mark=0 use=1\nudp      17 8 src=172.24.0.6 dst=192.168.65.2 sport=34632 dport=53 src=127.0.0.11 dst=172.24.0.6 sport=48495 dport=34632 mark=0 use=1\ntcp      6 81 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=40438 dport=8181 src=10.244.0.2 dst=10.244.0.1 sport=8181 dport=40438 [ASSURED] mark=0 use=1\ntcp      6 13 TIME_WAIT src=127.0.0.1 dst=127.0.0.1 sport=52352 dport=10257 src=127.0.0.1 dst=127.0.0.1 sport=10257 dport=52352 [ASSURED] mark=0 use=1\ntcp      6 47 TIME_WAIT src=127.0.0.1 dst=127.0.0.1 sport=39252 dport=2381 src=127.0.0.1 dst=127.0.0.1 sport=2381 dport=39252 [ASSURED] mark=0 use=1\ntcp      6 90 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=55488 dport=8080 src=10.244.0.2 dst=10.244.0.1 sport=8080 dport=55488 [ASSURED] mark=0 use=1\ntcp      6 71 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=40382 dport=8181 src=10.244.0.2 dst=10.244.0.1 sport=8181 dport=40382 [ASSURED] mark=0 use=1\ntcp      6 86398 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56408 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56408 [ASSURED] mark=0 use=1\ntcp      6 86395 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56350 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56350 [ASSURED] mark=0 use=1\ntcp      6 86399 ESTABLISHED src=172.24.0.2 dst=172.24.0.6 sport=51462 dport=6443 src=172.24.0.6 dst=172.24.0.2 sport=6443 dport=51462 [ASSURED] mark=0 use=1\ntcp      6 86385 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56328 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56328 [ASSURED] mark=0 use=1\ntcp      6 86387 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56392 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56392 [ASSURED] mark=0 use=1\ntcp      6 29 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=50844 dport=8080 src=10.244.0.3 dst=10.244.0.1 sport=8080 dport=50844 [ASSURED] mark=0 use=1\ntcp      6 86395 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56448 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56448 [ASSURED] mark=0 use=1\ntcp      6 50 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=55264 dport=8080 src=10.244.0.2 dst=10.244.0.1 sport=8080 dport=55264 [ASSURED] mark=0 use=1\ntcp      6 9 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=50732 dport=8080 src=10.244.0.3 dst=10.244.0.1 sport=8080 dport=50732 [ASSURED] mark=0 use=1\ntcp      6 43 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=45944 dport=8181 src=10.244.0.3 dst=10.244.0.1 sport=8181 dport=45944 [ASSURED] mark=0 use=1\ntcp      6 31 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=40158 dport=8181 src=10.244.0.2 dst=10.244.0.1 sport=8181 dport=40158 [ASSURED] mark=0 use=1\ntcp      6 86399 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56396 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56396 [ASSURED] mark=0 use=1\ntcp      6 86390 ESTABLISHED src=172.24.0.2 dst=172.24.0.6 sport=4547 dport=6443 src=172.24.0.6 dst=172.24.0.2 sport=6443 dport=4547 [ASSURED] mark=0 use=1\ntcp      6 7 TIME_WAIT src=127.0.0.1 dst=127.0.0.1 sport=39028 dport=2381 src=127.0.0.1 dst=127.0.0.1 sport=2381 dport=39028 [ASSURED] mark=0 use=1\ntcp      6 80 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=55432 dport=8080 src=10.244.0.2 dst=10.244.0.1 sport=8080 dport=55432 [ASSURED] mark=0 use=1\ntcp      6 107 TIME_WAIT src=127.0.0.1 dst=127.0.0.1 sport=39588 dport=2381 src=127.0.0.1 dst=127.0.0.1 sport=2381 dport=39588 [ASSURED] mark=0 use=1\ntcp      6 86393 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56330 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56330 [ASSURED] mark=0 use=2\ntcp      6 86399 ESTABLISHED src=172.24.0.6 dst=172.24.0.2 sport=37216 dport=10250 src=172.24.0.2 dst=172.24.0.6 sport=10250 dport=37216 [ASSURED] mark=0 use=1\ntcp      6 13 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=45776 dport=8181 src=10.244.0.3 dst=10.244.0.1 sport=8181 dport=45776 [ASSURED] mark=0 use=1\ntcp      6 41 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=40214 dport=8181 src=10.244.0.2 dst=10.244.0.1 sport=8181 dport=40214 [ASSURED] mark=0 use=1\ntcp      6 86399 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56382 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56382 [ASSURED] mark=0 use=1\ntcp      6 86399 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56352 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56352 [ASSURED] mark=0 use=1\ntcp      6 86392 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56398 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56398 [ASSURED] mark=0 use=1\ntcp      6 86399 ESTABLISHED src=10.244.0.2 dst=10.96.0.1 sport=59298 dport=443 src=172.24.0.6 dst=10.244.0.2 sport=6443 dport=59298 [ASSURED] mark=0 use=1\ntcp      6 27 TIME_WAIT src=127.0.0.1 dst=127.0.0.1 sport=39140 dport=2381 src=127.0.0.1 dst=127.0.0.1 sport=2381 dport=39140 [ASSURED] mark=0 use=1\ntcp      6 86391 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56428 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56428 [ASSURED] mark=0 use=1\ntcp      6 300 ESTABLISHED src=172.24.0.6 dst=172.24.0.6 sport=50330 dport=10250 src=172.24.0.6 dst=172.24.0.6 sport=10250 dport=50330 [ASSURED] mark=0 use=1\ntcp      6 86391 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56404 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56404 [ASSURED] mark=0 use=1\ntcp      6 59 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=51012 dport=8080 src=10.244.0.3 dst=10.244.0.1 sport=8080 dport=51012 [ASSURED] mark=0 use=1\ntcp      6 86396 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56358 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56358 [ASSURED] mark=0 use=1\ntcp      6 86399 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56374 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56374 [ASSURED] mark=0 use=1\ntcp      6 86391 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56460 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56460 [ASSURED] mark=0 use=1\ntcp      6 0 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=54984 dport=8080 src=10.244.0.2 dst=10.244.0.1 sport=8080 dport=54984 [ASSURED] mark=0 use=1\ntcp      6 86391 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56454 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56454 [ASSURED] mark=0 use=1\ntcp      6 86396 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56394 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56394 [ASSURED] mark=0 use=1\ntcp      6 86389 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56336 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56336 [ASSURED] mark=0 use=1\ntcp      6 77 TIME_WAIT src=127.0.0.1 dst=127.0.0.1 sport=39420 dport=2381 src=127.0.0.1 dst=127.0.0.1 sport=2381 dport=39420 [ASSURED] mark=0 use=1\ntcp      6 86398 ESTABLISHED src=172.24.0.6 dst=172.24.0.6 sport=51142 dport=6443 src=172.24.0.6 dst=172.24.0.6 sport=6443 dport=51142 [ASSURED] mark=0 use=1\ntcp      6 86391 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56368 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56368 [ASSURED] mark=0 use=1\ntcp      6 73 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=46112 dport=8181 src=10.244.0.3 dst=10.244.0.1 sport=8181 dport=46112 [ASSURED] mark=0 use=1\ntcp      6 86395 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56360 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56360 [ASSURED] mark=0 use=1\ntcp      6 86397 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56434 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56434 [ASSURED] mark=0 use=1\ntcp      6 86389 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56452 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56452 [ASSURED] mark=0 use=1\ntcp      6 86392 ESTABLISHED src=172.24.0.6 dst=10.96.0.1 sport=52754 dport=443 src=172.24.0.6 dst=172.24.0.6 sport=6443 dport=58061 [ASSURED] mark=0 use=1\ntcp      6 86399 ESTABLISHED src=172.24.0.1 dst=172.24.0.6 sport=54150 dport=6443 src=172.24.0.6 dst=172.24.0.1 sport=6443 dport=54150 [ASSURED] mark=0 use=1\ntcp      6 86388 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56410 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56410 [ASSURED] mark=0 use=1\ntcp      6 117 TIME_WAIT src=127.0.0.1 dst=127.0.0.1 sport=39644 dport=2381 src=127.0.0.1 dst=127.0.0.1 sport=2381 dport=39644 [ASSURED] mark=0 use=1\ntcp      6 113 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=46336 dport=8181 src=10.244.0.3 dst=10.244.0.1 sport=8181 dport=46336 [ASSURED] mark=0 use=1\nudp      17 18 src=172.24.0.6 dst=192.168.65.2 sport=59858 dport=53 src=127.0.0.11 dst=172.24.0.6 sport=48495 dport=59858 mark=0 use=1\ntcp      6 86390 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56446 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56446 [ASSURED] mark=0 use=1\ntcp      6 86399 ESTABLISHED src=172.24.0.6 dst=172.24.0.6 sport=51180 dport=6443 src=172.24.0.6 dst=172.24.0.6 sport=6443 dport=51180 [ASSURED] mark=0 use=1\n"
Jul 22 15:38:10.021: INFO: conntrack table of node three-node-control-plane: udp      17 18 src=172.24.0.6 dst=192.168.65.2 sport=56199 dport=53 src=127.0.0.11 dst=172.24.0.6 sport=48495 dport=56199 mark=0 use=1
tcp      6 86395 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56430 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56430 [ASSURED] mark=0 use=1
tcp      6 86399 ESTABLISHED src=172.24.0.1 dst=172.24.0.6 sport=54154 dport=6443 src=172.24.0.6 dst=172.24.0.1 sport=6443 dport=54154 [ASSURED] mark=0 use=1
tcp      6 61 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=40326 dport=8181 src=10.244.0.2 dst=10.244.0.1 sport=8181 dport=40326 [ASSURED] mark=0 use=1
tcp      6 70 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=55376 dport=8080 src=10.244.0.2 dst=10.244.0.1 sport=8080 dport=55376 [ASSURED] mark=0 use=1
tcp      6 86394 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56362 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56362 [ASSURED] mark=0 use=1
tcp      6 11 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=40046 dport=8181 src=10.244.0.2 dst=10.244.0.1 sport=8181 dport=40046 [ASSURED] mark=0 use=1
tcp      6 109 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=51292 dport=8080 src=10.244.0.3 dst=10.244.0.1 sport=8080 dport=51292 [ASSURED] mark=0 use=1
tcp      6 1 CLOSE src=172.24.0.6 dst=172.24.0.6 sport=44466 dport=6443 src=172.24.0.6 dst=172.24.0.6 sport=6443 dport=44466 [ASSURED] mark=0 use=1
tcp      6 97 TIME_WAIT src=127.0.0.1 dst=127.0.0.1 sport=39532 dport=2381 src=127.0.0.1 dst=127.0.0.1 sport=2381 dport=39532 [ASSURED] mark=0 use=1
tcp      6 23 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=45832 dport=8181 src=10.244.0.3 dst=10.244.0.1 sport=8181 dport=45832 [ASSURED] mark=0 use=1
tcp      6 86393 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56334 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56334 [ASSURED] mark=0 use=1
tcp      6 86389 ESTABLISHED src=172.24.0.6 dst=172.24.0.6 sport=50946 dport=6443 src=172.24.0.6 dst=172.24.0.6 sport=6443 dport=50946 [ASSURED] mark=0 use=1
tcp      6 57 TIME_WAIT src=127.0.0.1 dst=127.0.0.1 sport=39308 dport=2381 src=127.0.0.1 dst=127.0.0.1 sport=2381 dport=39308 [ASSURED] mark=0 use=1
tcp      6 86399 ESTABLISHED src=172.24.0.2 dst=172.24.0.6 sport=51510 dport=6443 src=172.24.0.6 dst=172.24.0.2 sport=6443 dport=51510 [ASSURED] mark=0 use=1
udp      17 28 src=172.24.0.6 dst=192.168.65.2 sport=33513 dport=53 src=127.0.0.11 dst=172.24.0.6 sport=48495 dport=33513 mark=0 use=1
tcp      6 86390 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56346 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56346 [ASSURED] mark=0 use=1
tcp      6 86391 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56344 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56344 [ASSURED] mark=0 use=1
tcp      6 86394 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56440 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56440 [ASSURED] mark=0 use=2
tcp      6 86389 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56412 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56412 [ASSURED] mark=0 use=1
tcp      6 86389 ESTABLISHED src=172.24.0.6 dst=172.24.0.6 sport=34102 dport=2379 src=172.24.0.6 dst=172.24.0.6 sport=2379 dport=34102 [ASSURED] mark=0 use=1
tcp      6 86389 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56324 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56324 [ASSURED] mark=0 use=1
tcp      6 86387 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56340 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56340 [ASSURED] mark=0 use=1
tcp      6 86398 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56380 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56380 [ASSURED] mark=0 use=1
tcp      6 83 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=46168 dport=8181 src=10.244.0.3 dst=10.244.0.1 sport=8181 dport=46168 [ASSURED] mark=0 use=1
tcp      6 86399 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56376 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56376 [ASSURED] mark=0 use=1
tcp      6 91 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=40494 dport=8181 src=10.244.0.2 dst=10.244.0.1 sport=8181 dport=40494 [ASSURED] mark=0 use=1
tcp      6 1 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=39990 dport=8181 src=10.244.0.2 dst=10.244.0.1 sport=8181 dport=39990 [ASSURED] mark=0 use=1
tcp      6 86399 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56416 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56416 [ASSURED] mark=0 use=1
tcp      6 86392 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56372 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56372 [ASSURED] mark=0 use=1
tcp      6 79 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=51124 dport=8080 src=10.244.0.3 dst=10.244.0.1 sport=8080 dport=51124 [ASSURED] mark=0 use=1
tcp      6 3 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=45720 dport=8181 src=10.244.0.3 dst=10.244.0.1 sport=8181 dport=45720 [ASSURED] mark=0 use=1
tcp      6 86399 ESTABLISHED src=172.24.0.5 dst=172.24.0.6 sport=36204 dport=6443 src=172.24.0.6 dst=172.24.0.5 sport=6443 dport=36204 [ASSURED] mark=0 use=1
tcp      6 86391 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56388 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56388 [ASSURED] mark=0 use=1
tcp      6 86398 ESTABLISHED src=172.24.0.5 dst=172.24.0.6 sport=36178 dport=6443 src=172.24.0.6 dst=172.24.0.5 sport=6443 dport=36178 [ASSURED] mark=0 use=1
tcp      6 87 TIME_WAIT src=127.0.0.1 dst=127.0.0.1 sport=39476 dport=2381 src=127.0.0.1 dst=127.0.0.1 sport=2381 dport=39476 [ASSURED] mark=0 use=1
tcp      6 86397 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56342 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56342 [ASSURED] mark=0 use=1
tcp      6 17 TIME_WAIT src=127.0.0.1 dst=127.0.0.1 sport=39084 dport=2381 src=127.0.0.1 dst=127.0.0.1 sport=2381 dport=39084 [ASSURED] mark=0 use=1
tcp      6 86399 ESTABLISHED src=172.24.0.6 dst=172.24.0.6 sport=51150 dport=6443 src=172.24.0.6 dst=172.24.0.6 sport=6443 dport=51150 [ASSURED] mark=0 use=1
tcp      6 10 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=55040 dport=8080 src=10.244.0.2 dst=10.244.0.1 sport=8080 dport=55040 [ASSURED] mark=0 use=1
tcp      6 61 TIME_WAIT src=172.24.0.6 dst=172.24.0.6 sport=44186 dport=6443 src=172.24.0.6 dst=172.24.0.6 sport=6443 dport=44186 [ASSURED] mark=0 use=1
tcp      6 299 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=42870 dport=45379 src=127.0.0.1 dst=127.0.0.1 sport=45379 dport=42870 [ASSURED] mark=0 use=1
tcp      6 21 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=40102 dport=8181 src=10.244.0.2 dst=10.244.0.1 sport=8181 dport=40102 [ASSURED] mark=0 use=1
tcp      6 86399 ESTABLISHED src=172.24.0.6 dst=172.24.0.6 sport=51164 dport=6443 src=172.24.0.6 dst=172.24.0.6 sport=6443 dport=51164 [ASSURED] mark=0 use=1
tcp      6 93 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=46224 dport=8181 src=10.244.0.3 dst=10.244.0.1 sport=8181 dport=46224 [ASSURED] mark=0 use=1
tcp      6 86399 ESTABLISHED src=172.24.0.1 dst=172.24.0.6 sport=47236 dport=6443 src=172.24.0.6 dst=172.24.0.1 sport=6443 dport=47236 [ASSURED] mark=0 use=1
tcp      6 30 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=55152 dport=8080 src=10.244.0.2 dst=10.244.0.1 sport=8080 dport=55152 [ASSURED] mark=0 use=1
tcp      6 86394 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56462 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56462 [ASSURED] mark=0 use=1
tcp      6 86399 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56450 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56450 [ASSURED] mark=0 use=1
tcp      6 3 CLOSE src=127.0.0.1 dst=127.0.0.1 sport=52912 dport=10257 src=127.0.0.1 dst=127.0.0.1 sport=10257 dport=52912 [ASSURED] mark=0 use=1
tcp      6 9 CLOSE src=172.24.0.1 dst=172.24.0.6 sport=54140 dport=6443 src=172.24.0.6 dst=172.24.0.1 sport=6443 dport=54140 [ASSURED] mark=0 use=1
tcp      6 9 CLOSE src=172.24.0.6 dst=172.24.0.2 sport=44110 dport=10250 src=172.24.0.2 dst=172.24.0.6 sport=10250 dport=44110 [ASSURED] mark=0 use=1
udp      17 28 src=172.24.0.6 dst=192.168.65.2 sport=50743 dport=53 src=127.0.0.11 dst=172.24.0.6 sport=48495 dport=50743 mark=0 use=1
tcp      6 99 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=51236 dport=8080 src=10.244.0.3 dst=10.244.0.1 sport=8080 dport=51236 [ASSURED] mark=0 use=1
tcp      6 86395 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56384 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56384 [ASSURED] mark=0 use=1
tcp      6 100 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=55544 dport=8080 src=10.244.0.2 dst=10.244.0.1 sport=8080 dport=55544 [ASSURED] mark=0 use=1
tcp      6 86394 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56442 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56442 [ASSURED] mark=0 use=2
tcp      6 119 TIME_WAIT src=172.24.0.1 dst=172.24.0.6 sport=54136 dport=6443 src=172.24.0.6 dst=172.24.0.1 sport=6443 dport=54136 [ASSURED] mark=0 use=1
tcp      6 86399 ESTABLISHED src=10.244.0.4 dst=10.96.0.1 sport=50344 dport=443 src=172.24.0.6 dst=10.244.0.4 sport=6443 dport=50344 [ASSURED] mark=0 use=1
tcp      6 67 TIME_WAIT src=127.0.0.1 dst=127.0.0.1 sport=39364 dport=2381 src=127.0.0.1 dst=127.0.0.1 sport=2381 dport=39364 [ASSURED] mark=0 use=1
tcp      6 86398 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56400 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56400 [ASSURED] mark=0 use=1
tcp      6 86385 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56378 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56378 [ASSURED] mark=0 use=1
tcp      6 86386 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56390 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56390 [ASSURED] mark=0 use=1
tcp      6 86393 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56436 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56436 [ASSURED] mark=0 use=1
tcp      6 86393 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56458 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56458 [ASSURED] mark=0 use=1
tcp      6 86397 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56456 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56456 [ASSURED] mark=0 use=1
tcp      6 86386 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56338 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56338 [ASSURED] mark=0 use=1
tcp      6 33 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=45888 dport=8181 src=10.244.0.3 dst=10.244.0.1 sport=8181 dport=45888 [ASSURED] mark=0 use=1
tcp      6 86397 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56370 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56370 [ASSURED] mark=0 use=1
tcp      6 86391 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56402 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56402 [ASSURED] mark=0 use=1
udp      17 8 src=172.24.0.6 dst=192.168.65.2 sport=39350 dport=53 src=127.0.0.11 dst=172.24.0.6 sport=48495 dport=39350 mark=0 use=1
tcp      6 86388 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56438 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56438 [ASSURED] mark=0 use=1
tcp      6 86398 ESTABLISHED src=172.24.0.5 dst=172.24.0.6 sport=26819 dport=6443 src=172.24.0.6 dst=172.24.0.5 sport=6443 dport=26819 [ASSURED] mark=0 use=1
tcp      6 69 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=51068 dport=8080 src=10.244.0.3 dst=10.244.0.1 sport=8080 dport=51068 [ASSURED] mark=0 use=1
tcp      6 110 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=55600 dport=8080 src=10.244.0.2 dst=10.244.0.1 sport=8080 dport=55600 [ASSURED] mark=0 use=1
tcp      6 73 TIME_WAIT src=127.0.0.1 dst=127.0.0.1 sport=52688 dport=10257 src=127.0.0.1 dst=127.0.0.1 sport=10257 dport=52688 [ASSURED] mark=0 use=1
tcp      6 86399 ESTABLISHED src=172.24.0.6 dst=172.24.0.6 sport=50950 dport=6443 src=172.24.0.6 dst=172.24.0.6 sport=6443 dport=50950 [ASSURED] mark=0 use=1
tcp      6 119 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=51348 dport=8080 src=10.244.0.3 dst=10.244.0.1 sport=8080 dport=51348 [ASSURED] mark=0 use=1
tcp      6 51 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=40270 dport=8181 src=10.244.0.2 dst=10.244.0.1 sport=8181 dport=40270 [ASSURED] mark=0 use=1
tcp      6 86394 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56364 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56364 [ASSURED] mark=0 use=1
tcp      6 86385 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56386 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56386 [ASSURED] mark=0 use=1
tcp      6 115 TIME_WAIT src=127.0.0.1 dst=127.0.0.1 sport=45494 dport=10259 src=127.0.0.1 dst=127.0.0.1 sport=10259 dport=45494 [ASSURED] mark=0 use=1
tcp      6 86390 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56444 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56444 [ASSURED] mark=0 use=1
tcp      6 53 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=46000 dport=8181 src=10.244.0.3 dst=10.244.0.1 sport=8181 dport=46000 [ASSURED] mark=0 use=1
tcp      6 86399 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56406 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56406 [ASSURED] mark=0 use=1
tcp      6 86388 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56424 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56424 [ASSURED] mark=0 use=1
tcp      6 86392 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56366 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56366 [ASSURED] mark=0 use=1
tcp      6 86399 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56356 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56356 [ASSURED] mark=0 use=1
tcp      6 86388 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56418 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56418 [ASSURED] mark=0 use=1
tcp      6 111 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=40606 dport=8181 src=10.244.0.2 dst=10.244.0.1 sport=8181 dport=40606 [ASSURED] mark=0 use=1
tcp      6 39 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=50900 dport=8080 src=10.244.0.3 dst=10.244.0.1 sport=8080 dport=50900 [ASSURED] mark=0 use=1
tcp      6 19 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=50788 dport=8080 src=10.244.0.3 dst=10.244.0.1 sport=8080 dport=50788 [ASSURED] mark=0 use=1
tcp      6 103 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=46280 dport=8181 src=10.244.0.3 dst=10.244.0.1 sport=8181 dport=46280 [ASSURED] mark=0 use=1
tcp      6 37 TIME_WAIT src=127.0.0.1 dst=127.0.0.1 sport=39196 dport=2381 src=127.0.0.1 dst=127.0.0.1 sport=2381 dport=39196 [ASSURED] mark=0 use=1
tcp      6 86399 ESTABLISHED src=10.244.0.3 dst=10.96.0.1 sport=43960 dport=443 src=172.24.0.6 dst=10.244.0.3 sport=6443 dport=43960 [ASSURED] mark=0 use=2
tcp      6 86397 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56420 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56420 [ASSURED] mark=0 use=1
tcp      6 40 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=55208 dport=8080 src=10.244.0.2 dst=10.244.0.1 sport=8080 dport=55208 [ASSURED] mark=0 use=1
tcp      6 86399 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56348 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56348 [ASSURED] mark=0 use=1
tcp      6 86399 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56414 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56414 [ASSURED] mark=0 use=1
tcp      6 86395 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56332 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56332 [ASSURED] mark=0 use=1
tcp      6 63 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=46056 dport=8181 src=10.244.0.3 dst=10.244.0.1 sport=8181 dport=46056 [ASSURED] mark=0 use=1
tcp      6 60 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=55320 dport=8080 src=10.244.0.2 dst=10.244.0.1 sport=8080 dport=55320 [ASSURED] mark=0 use=1
tcp      6 101 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=40550 dport=8181 src=10.244.0.2 dst=10.244.0.1 sport=8181 dport=40550 [ASSURED] mark=0 use=1
tcp      6 20 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=55096 dport=8080 src=10.244.0.2 dst=10.244.0.1 sport=8080 dport=55096 [ASSURED] mark=0 use=1
tcp      6 86399 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56354 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56354 [ASSURED] mark=0 use=1
tcp      6 86386 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56426 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56426 [ASSURED] mark=0 use=1
tcp      6 86395 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56314 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56314 [ASSURED] mark=0 use=1
tcp      6 86386 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56432 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56432 [ASSURED] mark=0 use=1
tcp      6 49 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=50956 dport=8080 src=10.244.0.3 dst=10.244.0.1 sport=8080 dport=50956 [ASSURED] mark=0 use=1
tcp      6 89 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=51180 dport=8080 src=10.244.0.3 dst=10.244.0.1 sport=8080 dport=51180 [ASSURED] mark=0 use=1
udp      17 8 src=172.24.0.6 dst=192.168.65.2 sport=34632 dport=53 src=127.0.0.11 dst=172.24.0.6 sport=48495 dport=34632 mark=0 use=1
tcp      6 81 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=40438 dport=8181 src=10.244.0.2 dst=10.244.0.1 sport=8181 dport=40438 [ASSURED] mark=0 use=1
tcp      6 13 TIME_WAIT src=127.0.0.1 dst=127.0.0.1 sport=52352 dport=10257 src=127.0.0.1 dst=127.0.0.1 sport=10257 dport=52352 [ASSURED] mark=0 use=1
tcp      6 47 TIME_WAIT src=127.0.0.1 dst=127.0.0.1 sport=39252 dport=2381 src=127.0.0.1 dst=127.0.0.1 sport=2381 dport=39252 [ASSURED] mark=0 use=1
tcp      6 90 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=55488 dport=8080 src=10.244.0.2 dst=10.244.0.1 sport=8080 dport=55488 [ASSURED] mark=0 use=1
tcp      6 71 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=40382 dport=8181 src=10.244.0.2 dst=10.244.0.1 sport=8181 dport=40382 [ASSURED] mark=0 use=1
tcp      6 86398 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56408 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56408 [ASSURED] mark=0 use=1
tcp      6 86395 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56350 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56350 [ASSURED] mark=0 use=1
tcp      6 86399 ESTABLISHED src=172.24.0.2 dst=172.24.0.6 sport=51462 dport=6443 src=172.24.0.6 dst=172.24.0.2 sport=6443 dport=51462 [ASSURED] mark=0 use=1
tcp      6 86385 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56328 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56328 [ASSURED] mark=0 use=1
tcp      6 86387 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56392 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56392 [ASSURED] mark=0 use=1
tcp      6 29 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=50844 dport=8080 src=10.244.0.3 dst=10.244.0.1 sport=8080 dport=50844 [ASSURED] mark=0 use=1
tcp      6 86395 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56448 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56448 [ASSURED] mark=0 use=1
tcp      6 50 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=55264 dport=8080 src=10.244.0.2 dst=10.244.0.1 sport=8080 dport=55264 [ASSURED] mark=0 use=1
tcp      6 9 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=50732 dport=8080 src=10.244.0.3 dst=10.244.0.1 sport=8080 dport=50732 [ASSURED] mark=0 use=1
tcp      6 43 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=45944 dport=8181 src=10.244.0.3 dst=10.244.0.1 sport=8181 dport=45944 [ASSURED] mark=0 use=1
tcp      6 31 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=40158 dport=8181 src=10.244.0.2 dst=10.244.0.1 sport=8181 dport=40158 [ASSURED] mark=0 use=1
tcp      6 86399 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56396 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56396 [ASSURED] mark=0 use=1
tcp      6 86390 ESTABLISHED src=172.24.0.2 dst=172.24.0.6 sport=4547 dport=6443 src=172.24.0.6 dst=172.24.0.2 sport=6443 dport=4547 [ASSURED] mark=0 use=1
tcp      6 7 TIME_WAIT src=127.0.0.1 dst=127.0.0.1 sport=39028 dport=2381 src=127.0.0.1 dst=127.0.0.1 sport=2381 dport=39028 [ASSURED] mark=0 use=1
tcp      6 80 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=55432 dport=8080 src=10.244.0.2 dst=10.244.0.1 sport=8080 dport=55432 [ASSURED] mark=0 use=1
tcp      6 107 TIME_WAIT src=127.0.0.1 dst=127.0.0.1 sport=39588 dport=2381 src=127.0.0.1 dst=127.0.0.1 sport=2381 dport=39588 [ASSURED] mark=0 use=1
tcp      6 86393 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56330 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56330 [ASSURED] mark=0 use=2
tcp      6 86399 ESTABLISHED src=172.24.0.6 dst=172.24.0.2 sport=37216 dport=10250 src=172.24.0.2 dst=172.24.0.6 sport=10250 dport=37216 [ASSURED] mark=0 use=1
tcp      6 13 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=45776 dport=8181 src=10.244.0.3 dst=10.244.0.1 sport=8181 dport=45776 [ASSURED] mark=0 use=1
tcp      6 41 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=40214 dport=8181 src=10.244.0.2 dst=10.244.0.1 sport=8181 dport=40214 [ASSURED] mark=0 use=1
tcp      6 86399 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56382 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56382 [ASSURED] mark=0 use=1
tcp      6 86399 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56352 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56352 [ASSURED] mark=0 use=1
tcp      6 86392 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56398 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56398 [ASSURED] mark=0 use=1
tcp      6 86399 ESTABLISHED src=10.244.0.2 dst=10.96.0.1 sport=59298 dport=443 src=172.24.0.6 dst=10.244.0.2 sport=6443 dport=59298 [ASSURED] mark=0 use=1
tcp      6 27 TIME_WAIT src=127.0.0.1 dst=127.0.0.1 sport=39140 dport=2381 src=127.0.0.1 dst=127.0.0.1 sport=2381 dport=39140 [ASSURED] mark=0 use=1
tcp      6 86391 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56428 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56428 [ASSURED] mark=0 use=1
tcp      6 300 ESTABLISHED src=172.24.0.6 dst=172.24.0.6 sport=50330 dport=10250 src=172.24.0.6 dst=172.24.0.6 sport=10250 dport=50330 [ASSURED] mark=0 use=1
tcp      6 86391 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56404 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56404 [ASSURED] mark=0 use=1
tcp      6 59 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=51012 dport=8080 src=10.244.0.3 dst=10.244.0.1 sport=8080 dport=51012 [ASSURED] mark=0 use=1
tcp      6 86396 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56358 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56358 [ASSURED] mark=0 use=1
tcp      6 86399 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56374 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56374 [ASSURED] mark=0 use=1
tcp      6 86391 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56460 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56460 [ASSURED] mark=0 use=1
tcp      6 0 TIME_WAIT src=10.244.0.1 dst=10.244.0.2 sport=54984 dport=8080 src=10.244.0.2 dst=10.244.0.1 sport=8080 dport=54984 [ASSURED] mark=0 use=1
tcp      6 86391 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56454 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56454 [ASSURED] mark=0 use=1
tcp      6 86396 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56394 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56394 [ASSURED] mark=0 use=1
tcp      6 86389 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56336 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56336 [ASSURED] mark=0 use=1
tcp      6 77 TIME_WAIT src=127.0.0.1 dst=127.0.0.1 sport=39420 dport=2381 src=127.0.0.1 dst=127.0.0.1 sport=2381 dport=39420 [ASSURED] mark=0 use=1
tcp      6 86398 ESTABLISHED src=172.24.0.6 dst=172.24.0.6 sport=51142 dport=6443 src=172.24.0.6 dst=172.24.0.6 sport=6443 dport=51142 [ASSURED] mark=0 use=1
tcp      6 86391 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56368 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56368 [ASSURED] mark=0 use=1
tcp      6 73 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=46112 dport=8181 src=10.244.0.3 dst=10.244.0.1 sport=8181 dport=46112 [ASSURED] mark=0 use=1
tcp      6 86395 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56360 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56360 [ASSURED] mark=0 use=1
tcp      6 86397 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56434 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56434 [ASSURED] mark=0 use=1
tcp      6 86389 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56452 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56452 [ASSURED] mark=0 use=1
tcp      6 86392 ESTABLISHED src=172.24.0.6 dst=10.96.0.1 sport=52754 dport=443 src=172.24.0.6 dst=172.24.0.6 sport=6443 dport=58061 [ASSURED] mark=0 use=1
tcp      6 86399 ESTABLISHED src=172.24.0.1 dst=172.24.0.6 sport=54150 dport=6443 src=172.24.0.6 dst=172.24.0.1 sport=6443 dport=54150 [ASSURED] mark=0 use=1
tcp      6 86388 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56410 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56410 [ASSURED] mark=0 use=1
tcp      6 117 TIME_WAIT src=127.0.0.1 dst=127.0.0.1 sport=39644 dport=2381 src=127.0.0.1 dst=127.0.0.1 sport=2381 dport=39644 [ASSURED] mark=0 use=1
tcp      6 113 TIME_WAIT src=10.244.0.1 dst=10.244.0.3 sport=46336 dport=8181 src=10.244.0.3 dst=10.244.0.1 sport=8181 dport=46336 [ASSURED] mark=0 use=1
udp      17 18 src=172.24.0.6 dst=192.168.65.2 sport=59858 dport=53 src=127.0.0.11 dst=172.24.0.6 sport=48495 dport=59858 mark=0 use=1
tcp      6 86390 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=56446 dport=2379 src=127.0.0.1 dst=127.0.0.1 sport=2379 dport=56446 [ASSURED] mark=0 use=1
tcp      6 86399 ESTABLISHED src=172.24.0.6 dst=172.24.0.6 sport=51180 dport=6443 src=172.24.0.6 dst=172.24.0.6 sport=6443 dport=51180 [ASSURED] mark=0 use=1

Jul 22 15:38:10.022: INFO: Running '/usr/local/bin/kubectl --server=https://127.0.0.1:50395 --kubeconfig=/Users/mfenwick/.kube/config exec --namespace=kube-system kube-proxy-rfgfw -- /bin/sh -x -c conntrack -L'
Jul 22 15:38:10.173: INFO: stderr: "+ conntrack -L\nconntrack v1.4.5 (conntrack-tools): 12 flow entries have been shown.\n"
Jul 22 15:38:10.173: INFO: stdout: "udp      17 28 src=172.24.0.5 dst=192.168.65.2 sport=56266 dport=53 src=127.0.0.11 dst=172.24.0.5 sport=49113 dport=56266 mark=0 use=1\nudp      17 18 src=172.24.0.5 dst=192.168.65.2 sport=34603 dport=53 src=127.0.0.11 dst=172.24.0.5 sport=49113 dport=34603 mark=0 use=1\ntcp      6 86399 ESTABLISHED src=172.24.0.5 dst=172.24.0.6 sport=36204 dport=6443 src=172.24.0.6 dst=172.24.0.5 sport=6443 dport=36204 [ASSURED] mark=0 use=1\nudp      17 8 src=172.24.0.5 dst=192.168.65.2 sport=47027 dport=53 src=127.0.0.11 dst=172.24.0.5 sport=49113 dport=47027 mark=0 use=1\nudp      17 8 src=172.24.0.5 dst=192.168.65.2 sport=52320 dport=53 src=127.0.0.11 dst=172.24.0.5 sport=49113 dport=52320 mark=0 use=1\nudp      17 28 src=172.24.0.5 dst=192.168.65.2 sport=33474 dport=53 src=127.0.0.11 dst=172.24.0.5 sport=49113 dport=33474 mark=0 use=1\nudp      17 18 src=172.24.0.5 dst=192.168.65.2 sport=49940 dport=53 src=127.0.0.11 dst=172.24.0.5 sport=49113 dport=49940 mark=0 use=1\ntcp      6 86399 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=43438 dport=39309 src=127.0.0.1 dst=127.0.0.1 sport=39309 dport=43438 [ASSURED] mark=0 use=1\ntcp      6 86398 ESTABLISHED src=172.24.0.5 dst=10.96.0.1 sport=38540 dport=443 src=172.24.0.6 dst=172.24.0.5 sport=6443 dport=26819 [ASSURED] mark=0 use=1\nudp      17 175 src=172.24.0.2 dst=172.24.0.5 sport=12345 dport=31187 src=10.244.1.175 dst=10.244.1.1 sport=80 dport=49860 [ASSURED] mark=0 use=1\ntcp      6 86399 ESTABLISHED src=172.24.0.6 dst=172.24.0.5 sport=58426 dport=10250 src=172.24.0.5 dst=172.24.0.6 sport=10250 dport=58426 [ASSURED] mark=0 use=1\ntcp      6 86399 ESTABLISHED src=172.24.0.5 dst=172.24.0.6 sport=36178 dport=6443 src=172.24.0.6 dst=172.24.0.5 sport=6443 dport=36178 [ASSURED] mark=0 use=1\n"
Jul 22 15:38:10.173: INFO: conntrack table of node three-node-worker2: udp      17 28 src=172.24.0.5 dst=192.168.65.2 sport=56266 dport=53 src=127.0.0.11 dst=172.24.0.5 sport=49113 dport=56266 mark=0 use=1
udp      17 18 src=172.24.0.5 dst=192.168.65.2 sport=34603 dport=53 src=127.0.0.11 dst=172.24.0.5 sport=49113 dport=34603 mark=0 use=1
tcp      6 86399 ESTABLISHED src=172.24.0.5 dst=172.24.0.6 sport=36204 dport=6443 src=172.24.0.6 dst=172.24.0.5 sport=6443 dport=36204 [ASSURED] mark=0 use=1
udp      17 8 src=172.24.0.5 dst=192.168.65.2 sport=47027 dport=53 src=127.0.0.11 dst=172.24.0.5 sport=49113 dport=47027 mark=0 use=1
udp      17 8 src=172.24.0.5 dst=192.168.65.2 sport=52320 dport=53 src=127.0.0.11 dst=172.24.0.5 sport=49113 dport=52320 mark=0 use=1
udp      17 28 src=172.24.0.5 dst=192.168.65.2 sport=33474 dport=53 src=127.0.0.11 dst=172.24.0.5 sport=49113 dport=33474 mark=0 use=1
udp      17 18 src=172.24.0.5 dst=192.168.65.2 sport=49940 dport=53 src=127.0.0.11 dst=172.24.0.5 sport=49113 dport=49940 mark=0 use=1
tcp      6 86399 ESTABLISHED src=127.0.0.1 dst=127.0.0.1 sport=43438 dport=39309 src=127.0.0.1 dst=127.0.0.1 sport=39309 dport=43438 [ASSURED] mark=0 use=1
tcp      6 86398 ESTABLISHED src=172.24.0.5 dst=10.96.0.1 sport=38540 dport=443 src=172.24.0.6 dst=172.24.0.5 sport=6443 dport=26819 [ASSURED] mark=0 use=1
udp      17 175 src=172.24.0.2 dst=172.24.0.5 sport=12345 dport=31187 src=10.244.1.175 dst=10.244.1.1 sport=80 dport=49860 [ASSURED] mark=0 use=1
tcp      6 86399 ESTABLISHED src=172.24.0.6 dst=172.24.0.5 sport=58426 dport=10250 src=172.24.0.5 dst=172.24.0.6 sport=10250 dport=58426 [ASSURED] mark=0 use=1
tcp      6 86399 ESTABLISHED src=172.24.0.5 dst=172.24.0.6 sport=36178 dport=6443 src=172.24.0.6 dst=172.24.0.5 sport=6443 dport=36178 [ASSURED] mark=0 use=1

[AfterEach] [sig-network] Conntrack
  /Users/mfenwick/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:175
Jul 22 15:38:10.173: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
STEP: Destroying namespace "conntrack-1620" for this suite.

• [SLOW TEST:1230.255 seconds]
[sig-network] Conntrack
/Users/mfenwick/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:23
  should be able to preserve UDP traffic when server pod cycles for a NodePort service
  /Users/mfenwick/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/network/conntrack.go:120
------------------------------
{"msg":"PASSED [sig-network] Conntrack should be able to preserve UDP traffic when server pod cycles for a NodePort service","total":1,"completed":1,"skipped":1539,"failed":0}
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSJul 22 15:38:10.198: INFO: Running AfterSuite actions on all nodes
Jul 22 15:38:10.198: INFO: Running AfterSuite actions on node 1
{"msg":"Test Suite completed","total":1,"completed":1,"skipped":5239,"failed":0}

Ran 1 of 5240 Specs in 1230.337 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 5239 Skipped
PASS
```