### PR TITLE
Cleanup: add a godoc for isNodeConditionSetAsExpected

### DIFF
--- a/test/e2e/framework/node/resource.go
+++ b/test/e2e/framework/node/resource.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	testutils "k8s.io/kubernetes/test/utils"
 	"net"
 	"strings"
 	"time"
@@ -42,6 +41,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	clientretry "k8s.io/client-go/util/retry"
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
+	testutils "k8s.io/kubernetes/test/utils"
 
 	// TODO remove the direct dependency for internal k8s.io/kubernetes
 	"k8s.io/kubernetes/test/e2e/system"

--- a/test/utils/node.go
+++ b/test/utils/node.go
@@ -18,19 +18,20 @@ package utils
 
 import (
 	"fmt"
-	"k8s.io/api/core/v1"
+
+	v1 "k8s.io/api/core/v1"
 )
 
 var (
 	// unreachableTaintTemplate is the taint for when a node becomes unreachable.
-	// Copied from pkg/controller/nodelifecycle to avoid pulling extra dependencies
+	// Copied from pkg/controller/nodelifecycle to avoid pulling extra dependencies.
 	unreachableTaintTemplate = &v1.Taint{
 		Key:    v1.TaintNodeUnreachable,
 		Effect: v1.TaintEffectNoExecute,
 	}
 
 	// notReadyTaintTemplate is the taint for when a node is not ready for executing pods.
-	// Copied from pkg/controller/nodelifecycle to avoid pulling extra dependencies
+	// Copied from pkg/controller/nodelifecycle to avoid pulling extra dependencies.
 	notReadyTaintTemplate = &v1.Taint{
 		Key:    v1.TaintNodeNotReady,
 		Effect: v1.TaintEffectNoExecute,
@@ -51,6 +52,7 @@ func GetNodeCondition(status *v1.NodeStatus, conditionType v1.NodeConditionType)
 	return -1, nil
 }
 
+// IsNodeConditionSetAsExpected checks if a node condition is set as expected or not.
 func IsNodeConditionSetAsExpected(node *v1.Node, conditionType v1.NodeConditionType, wantTrue, silent bool, logFunc func(fmt string, args ...interface{})) bool {
 	// Check the node readiness condition (logging all).
 	for _, cond := range node.Status.Conditions {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup
/sig node
/priority backlog

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #93965

**Special notes for your reviewer**:

This PR is also a fix for [kubernetes#93965](https://github.com/kubernetes/kubernetes/issues/93965). I noticed your PR [#93983](https://github.com/kubernetes/kubernetes/pull/93983) deduplicating the isNodeConditionSetAsExpected function. However, there may be some goimports warnings and lacks of a godoc and I've added them for you. Hoping these can help improve the code ^_^. You may cherry-pick my commit or modify code by yourself to avoid an extra Merge commit.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
